### PR TITLE
:bug: Correct bug that introduce 0 in column names 

### DIFF
--- a/mag_annotator/annotate_bins.py
+++ b/mag_annotator/annotate_bins.py
@@ -880,6 +880,8 @@ def annotate_orfs(gene_faa, db_handler, tmp_dir, start_time, custom_db_locs=(), 
 
     # merge dataframes
     print('%s: Merging ORF annotations' % str(datetime.now() - start_time))
+    
+    annotation_list = [annotation for annotation in annotation_list if not annotation.empty]
     annotations = pd.concat(annotation_list, axis=1, sort=False)
 
     # get scaffold data and assign grades

--- a/mag_annotator/annotate_bins.py
+++ b/mag_annotator/annotate_bins.py
@@ -887,7 +887,7 @@ def annotate_orfs(gene_faa, db_handler, tmp_dir, start_time, custom_db_locs=(), 
     annotations = pd.concat([grades, annotations], axis=1, sort=False)
     
     columns_name_string = [name for name in annotations.columns if type(name) == str]
-    annotations = annotation[columns_name_string]
+    annotations = annotations[columns_name_string]
     
     return annotations
 

--- a/mag_annotator/annotate_bins.py
+++ b/mag_annotator/annotate_bins.py
@@ -880,13 +880,15 @@ def annotate_orfs(gene_faa, db_handler, tmp_dir, start_time, custom_db_locs=(), 
 
     # merge dataframes
     print('%s: Merging ORF annotations' % str(datetime.now() - start_time))
-    
-    annotation_list = [annotation for annotation in annotation_list if not annotation.empty]
     annotations = pd.concat(annotation_list, axis=1, sort=False)
-
+    
     # get scaffold data and assign grades
     grades = assign_grades(annotations)
     annotations = pd.concat([grades, annotations], axis=1, sort=False)
+    
+    columns_name_string = [name for name in annotations.columns if type(name) == str]
+    annotations = annotation[columns_name_string]
+    
     return annotations
 
 

--- a/mag_annotator/annotate_vgfs.py
+++ b/mag_annotator/annotate_vgfs.py
@@ -291,7 +291,7 @@ def get_metabolic_flags(annotations, metabolic_genes, amgs, verified_amgs, scaff
             flags = ''
             gene_annotations = set(get_ids_from_annotation(pd.DataFrame(row).transpose()).keys())  # TODO: Fix
             # is viral
-            if not pd.isna(row['vogdb_categories']):
+            if 'vogdb_categories' in row.index and not pd.isna(row['vogdb_categories']):
                 if len({'Xr', 'Xs'} & set(row['vogdb_categories'].split(';'))) > 0:
                     flags += 'V'
             # is metabolic


### PR DESCRIPTION
There was a bug that introduce 0 if the series is empty with no name.

This quick fix just remove the column names that are not string

The bug explains in detail:

When running my file it says that it couldn't find attribute "endswith" for one of the columns because it was an "int"

```python3
  File "/backup/user_data/remi/paleofeces_colab/virome_pipeline/.snakemake/conda/59b48c7ffd204d98ec79fb0b6fb72e74/lib/python3.9/site-packages/mag_annotator/annotate_bins.py", line 500, in annotate_gff
    annotations_to_add = {strip_endings(i, ['_id']): annotations.loc[old_gene_name, i]
  File "/backup/user_data/remi/paleofeces_colab/virome_pipeline/.snakemake/conda/59b48c7ffd204d98ec79fb0b6fb72e74/lib/python3.9/site-packages/mag_annotator/annotate_bins.py", line 501, in <dictcomp>
    for i in annotations.columns if i.endswith('_id')}
AttributeError: 'int' object has no attribute 'endswith'

```

When you look at the columns it appeared that a "0" was on the columns of the "annotations" dataframe

```python3
Index([                   'scaffold',               'gene_position',
                    'start_position',                'end_position',
                      'strandedness',                        'rank',
                          'viral_id',                   'viral_hit',
                         'viral_RBH',              'viral_identity',
                    'viral_bitScore',                  'viral_eVal',
                         'pfam_hits',                             0,
                          'vogdb_id',                  'vogdb_hits',
                  'vogdb_categories', 'heme_regulatory_motif_count'],
      dtype='object')
```

After looking deeply into when it appeared at first, I saw that it is when all the annotations where concatenate into one dataframe as the list of annotations present empty dataframes and series

```bash
.......
Empty DataFrame
Columns: []
Index: []
.......
                                viral_id  ...    viral_eVal
k119_10191__full-cat_2_6  YP_009001225.1  ...  8.940000e-19
k119_10191__full-cat_2_7  YP_009909519.1  ...  4.661000e-19

[2 rows x 6 columns]
.......
Empty DataFrame
Columns: []
Index: []
.......
k119_10191__full-cat_2_1                        VanZ like family [PF04892.15]
k119_10191__full-cat_2_3    Histidine kinase-, DNA gyrase B-, and HSP90-li...
k119_10191__full-cat_2_4    Response regulator receiver domain [PF00072.27...
k119_10191__full-cat_2_6                         ABC transporter [PF00005.30]
k119_10191__full-cat_2_7    ABC transporter [PF00005.30]; RecF/RecN/SMC N ...
Name: pfam_hits, dtype: object
.......
Series([], dtype: float64)
.......
                          vogdb_id  ... vogdb_categories
k119_10191__full-cat_2_7  VOG10397  ...               Xh
k119_10191__full-cat_2_6  VOG10397  ...               Xh
k119_10191__full-cat_2_4  VOG24783  ...               Xu

[3 rows x 3 columns]
.......
k119_10191__full-cat_2_1    0
k119_10191__full-cat_2_2    0
k119_10191__full-cat_2_3    0
k119_10191__full-cat_2_4    0
k119_10191__full-cat_2_5    0
k119_10191__full-cat_2_6    0
k119_10191__full-cat_2_7    0
Name: heme_regulatory_motif_count, dtype: int64
```

And if we print the column names or name of the series:

```bash
.......
Index([], dtype='object')
.......
Index(['viral_id', 'viral_hit', 'viral_RBH', 'viral_identity',
       'viral_bitScore', 'viral_eVal'],
      dtype='object')
.......
Index([], dtype='object')
.......
pfam_hits
.......
None
.......
Index(['vogdb_id', 'vogdb_hits', 'vogdb_categories'], dtype='object')
.......
heme_regulatory_motif_count
```

I know that it is a quick fix and maybe the good fix could be to make sure that every DataFrame or Series have a columns name or series name before concatenate them into one big dataframe
 