### PR TITLE
Update environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - mmseqs2!=10.6d92c
   - hmmer!=3.3.1
   - trnascan-se >=2
-  - scipy!=1.9.0
+  - scipy<=1.8.1
   - sqlalchemy
   - barrnap
   - altair >=4


### PR DESCRIPTION
Scipy 1.9.1 was recently released on conda-forge:
https://anaconda.org/conda-forge/scipy/files
which causes creating a new environment in conda to use Scipy 1.9.1, which satisfies the original condition of scipy!=1.9.0.  With Scipy 1.9.1, this error can occur:

ImportError: cannot import name 'PearsonRConstantInputWarning' from 'scipy.stats' (/projects/dram/anaconda3/envs/DRAM/lib/python3.10/sitepackages/scipy/stats/__init__.py)

Setting the version to be below (or equal to) scipy 1.8.1 should fix the issue!