### PR TITLE
Fixing a bug in setup

### DIFF
--- a/mag_annotator/database_handler.py
+++ b/mag_annotator/database_handler.py
@@ -141,6 +141,12 @@ class DatabaseHandler:
         self.config_loc = system_config_loc
 
         # read in configuration # TODO: validate config file after reading it in
+        if 'viral_refseq' in config_old:
+            config_old['viral'] = config_old.get('viral_refseq')
+        if 'kofam' in config_old:
+            config_old['kofam_hmm'] = config_old.get('kofam')
+        if 'pfam_hmm_dat' in config_old:
+            config_old['pfam_hmm'] = config_old.get('pfam_hmm_dat')
         self.config["search_databases"] = {
             key: value for key, value in config_old.items() if key in SEARCH_DATABASES
         }
@@ -248,7 +254,7 @@ class DatabaseHandler:
         dbcan_loc=None,
         dbcan_fam_activities_loc=None,
         dbcan_subfam_ec_loc=None,
-        viral_refseq_loc=None,
+        viral_loc=None,
         peptidase_loc=None,
         vogdb_loc=None,
         vog_annotations_loc=None,
@@ -278,7 +284,7 @@ class DatabaseHandler:
                 "uniref": uniref_loc,
                 "pfam": pfam_loc,
                 "dbcan": dbcan_loc,
-                "viral": viral_refseq_loc,
+                "viral": viral_loc,
                 "peptidase": peptidase_loc,
                 "vogdb": vogdb_loc,
             },
@@ -580,6 +586,7 @@ def print_database_locations(config_loc=None):
     )
     print("VOGDB db: %s" % conf.config.get("search_databases").get("vogdb"))
     # database descriptions used during description db population
+    print()
     print("Descriptions of search database entries")
     print("Pfam hmm dat: %s" % conf.config.get("database_descriptions").get("pfam_hmm"))
     print(

--- a/mag_annotator/summarize_genomes.py
+++ b/mag_annotator/summarize_genomes.py
@@ -42,15 +42,6 @@ ID_FUNCTION_DICT = {
     'kegg_hit': lambda x: [i[1:-1] for i in
                            re.findall(r'\[EC:\d*.\d*.\d*.\d*\]', x)],
     'peptidase_family': lambda x: [j for j in x.split(';')],
-    # 'cazy_ids': lambda x: [i.split('_')[0] for i in x.split('; ')],
-    # 'cazy_id': lambda x: [i.split('_')[0] for i in x.split('; ')],
-    # 'cazy_hits': lambda x: [f"{i[1:3]}:{i[4:-1]}" for i in
-    #                         re.findall(r'\(EC [\d+\.]+[\d-]\)', x)
-    #                         ] + [
-    #                         i[1:-1].split('_')[0]
-    #                         for i in re.findall(r'\[[A-Z]*\d*?\]', x)],
-    # 'cazy_subfam_ec': lambda x: [f"EC:{i}" for i in
-    #                              re.findall(r'[\d+\.]+[\d-]', x)],
     'cazy_best_hit': lambda x: [x.split('_')[0]],
     'pfam_hits': lambda x: [j[1:-1].split('.')[0]
                             for j in re.findall(r'\[PF\d\d\d\d\d.\d*\]', x)],

--- a/scripts/DRAM-setup.py
+++ b/scripts/DRAM-setup.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
     set_db_locs_parser.add_argument('--vog_annotations_loc', default=None,
                                     help='vog annotations file') # add loc to vog_annotations to match the rest
 
-    set_db_locs_parser.add_argument('--viral_refseq_loc', default=None,
+    set_db_locs_parser.add_argument('--viral_loc', default=None,
                                     help='mmseqs2 database file from ref seq viral gene collection')
     set_db_locs_parser.add_argument('--peptidase_loc', default=None,
                                     help='mmseqs2 database file from MEROPS database')


### PR DESCRIPTION
My last bug fix introduced a worse bug in the setup of DRAM. The main problem was that the viral ref-seqs db would not match to its name in the dram config dictionary, and so would fail to be written to config. This will also fix an error where in some imported old (pre 1.4 dram) config names would not match to the new config.