### PR TITLE
Fix bug that wasn't running annotations on all input fasta

### DIFF
--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -66,7 +66,7 @@ workflow ANNOTATE {
     take:
     ch_gene_locs  // channel: [ val(input_fasta name), path(gene_locs_tsv) ]
     ch_called_proteins  // channel: [ val(input_fasta name), path(called_proteins_file.faa) ]
-    ch_dummy_sheet // Path to dummy sheet
+    default_sheet // Path to dummy sheet
 
     main:
 
@@ -122,7 +122,7 @@ workflow ANNOTATE {
     // KEGG annotation
     if (params.use_kegg) {
         ch_combined_query_locs_kegg = ch_mmseqs_query.join(ch_gene_locs)
-        MMSEQS_SEARCH_KEGG( ch_combined_query_locs_kegg, DB_CHANNEL_SETUP.out.ch_kegg_db, params.bit_score_threshold, params.rbh_bit_score_threshold, ch_dummy_sheet, kegg_name )
+        MMSEQS_SEARCH_KEGG( ch_combined_query_locs_kegg, DB_CHANNEL_SETUP.out.ch_kegg_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, kegg_name )
         ch_kegg_unformatted = MMSEQS_SEARCH_KEGG.out.mmseqs_search_formatted_out
 
         SQL_KEGG(ch_kegg_unformatted, kegg_name, ch_sql_descriptions_db)
@@ -147,7 +147,7 @@ workflow ANNOTATE {
     // PFAM annotation
     if (params.use_pfam) {
         ch_combined_query_locs_pfam = ch_mmseqs_query.join(ch_gene_locs)
-        MMSEQS_SEARCH_PFAM( ch_combined_query_locs_pfam, DB_CHANNEL_SETUP.out.ch_pfam_mmseqs_db, params.bit_score_threshold, params.rbh_bit_score_threshold, ch_dummy_sheet, pfam_name )
+        MMSEQS_SEARCH_PFAM( ch_combined_query_locs_pfam, DB_CHANNEL_SETUP.out.ch_pfam_mmseqs_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, pfam_name )
         ch_pfam_unformatted = MMSEQS_SEARCH_PFAM.out.mmseqs_search_formatted_out
 
         SQL_PFAM(ch_pfam_unformatted, pfam_name, ch_sql_descriptions_db)
@@ -208,7 +208,7 @@ workflow ANNOTATE {
     // Methyl annotation
     if (params.use_methyl) {
         ch_combined_query_locs_methyl = ch_mmseqs_query.join(ch_gene_locs)
-        MMSEQS_SEARCH_METHYL( ch_combined_query_locs_methyl, DB_CHANNEL_SETUP.out.ch_methyl_db, params.bit_score_threshold, params.rbh_bit_score_threshold, ch_dummy_sheet, methyl_name )
+        MMSEQS_SEARCH_METHYL( ch_combined_query_locs_methyl, DB_CHANNEL_SETUP.out.ch_methyl_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, methyl_name )
         ch_methyl_mmseqs_formatted = MMSEQS_SEARCH_METHYL.out.mmseqs_search_formatted_out
 
         formattedOutputChannels = formattedOutputChannels.mix(ch_methyl_mmseqs_formatted)
@@ -253,7 +253,7 @@ workflow ANNOTATE {
     // MEROPS annotation
     if (params.use_merops) {
         ch_combined_query_locs_merops = ch_mmseqs_query.join(ch_gene_locs)
-        MMSEQS_SEARCH_MEROPS( ch_combined_query_locs_merops, DB_CHANNEL_SETUP.out.ch_merops_db, params.bit_score_threshold, params.rbh_bit_score_threshold, ch_dummy_sheet, merops_name )
+        MMSEQS_SEARCH_MEROPS( ch_combined_query_locs_merops, DB_CHANNEL_SETUP.out.ch_merops_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, merops_name )
         ch_merops_unformatted = MMSEQS_SEARCH_MEROPS.out.mmseqs_search_formatted_out
 
         SQL_MEROPS(ch_merops_unformatted, merops_name, ch_sql_descriptions_db)
@@ -264,7 +264,7 @@ workflow ANNOTATE {
     // Uniref annotation
     if (params.use_uniref) {
         ch_combined_query_locs_uniref = ch_mmseqs_query.join(ch_gene_locs)
-        MMSEQS_SEARCH_UNIREF( ch_combined_query_locs_uniref, DB_CHANNEL_SETUP.out.ch_uniref_db, params.bit_score_threshold, params.rbh_bit_score_threshold, ch_dummy_sheet, uniref_name )
+        MMSEQS_SEARCH_UNIREF( ch_combined_query_locs_uniref, DB_CHANNEL_SETUP.out.ch_uniref_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, uniref_name )
         ch_uniref_unformatted = MMSEQS_SEARCH_UNIREF.out.mmseqs_search_formatted_out
 
         SQL_UNIREF(ch_uniref_unformatted, uniref_name, ch_sql_descriptions_db)
@@ -289,7 +289,7 @@ workflow ANNOTATE {
     // Viral annotation
     if (params.use_viral) {
         ch_combined_query_locs_viral = ch_mmseqs_query.join(ch_gene_locs)
-        MMSEQS_SEARCH_VIRAL( ch_combined_query_locs_viral, DB_CHANNEL_SETUP.out.ch_viral_db, params.bit_score_threshold,  params.rbh_bit_score_threshold,ch_dummy_sheet, viral_name )
+        MMSEQS_SEARCH_VIRAL( ch_combined_query_locs_viral, DB_CHANNEL_SETUP.out.ch_viral_db, params.bit_score_threshold,  params.rbh_bit_score_threshold,default_sheet, viral_name )
         ch_viral_unformatted = MMSEQS_SEARCH_VIRAL.out.mmseqs_search_formatted_out
 
         SQL_VIRAL(ch_viral_unformatted, viral_name, ch_sql_descriptions_db)

--- a/workflows/dram.nf
+++ b/workflows/dram.nf
@@ -40,7 +40,7 @@ workflow DRAM {
     ch_versions = Channel.empty()
     ch_multiqc_files = Channel.empty()
 
-    default_channel = Channel.fromPath(params.distill_dummy_sheet)
+    default_sheet = file(params.distill_dummy_sheet)
     ch_fasta = getFastaChannel(params.input_fasta, params.fasta_fmt)
     distill_flag = (params.distill_topic != "" || params.distill_ecosystem != "" || params.distill_custom != "")
 
@@ -121,41 +121,41 @@ workflow DRAM {
             ch_distill_carbon = file(params.distill_carbon_sheet).exists() ? file(params.distill_carbon_sheet) : error("Error: If using --distill_topic carbon (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_carbon = default_channel
+            ch_distill_carbon = default_sheet
         }
         if (distill_energy == "1") {
             ch_distill_energy = file(params.distill_energy_sheet).exists() ? file(params.distill_energy_sheet) : error("Error: If using --distill_topic energy (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_energy = default_channel
+            ch_distill_energy = default_sheet
         }
 
         if (distill_misc == "1") {
             ch_distill_misc = file(params.distill_misc_sheet).exists() ? file(params.distill_misc_sheet) : error("Error: If using --distill_topic misc (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_misc = default_channel
+            ch_distill_misc = default_sheet
         }
 
         if (distill_nitrogen == "1") {
             ch_distill_nitrogen = file(params.distill_nitrogen_sheet).exists() ? file(params.distill_nitrogen_sheet) : error("Error: If using --distill_topic nitrogen (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_nitrogen = default_channel
+            ch_distill_nitrogen = default_sheet
         }
 
         if (distill_transport == "1") {
             ch_distill_transport = file(params.distill_transport_sheet).exists() ? file(params.distill_transport_sheet) : error("Error: If using --distill_topic transport (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_transport = default_channel
+            ch_distill_transport = default_sheet
         }
 
         if (distill_camper == "1") {
             ch_distill_camper = file(params.distill_camper_sheet).exists() ? file(params.distill_camper_sheet) : error("Error: If using --distill_topic camper, you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_camper = default_channel
+            ch_distill_camper = default_sheet
         }
 
         distill_eng_sys = "0"
@@ -188,21 +188,21 @@ workflow DRAM {
             ch_distill_eng_sys = file(params.distill_eng_sys_sheet).exists() ? file(params.distill_eng_sys_sheet) : error("Error: If using --distill_ecosystem eng_sys, you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_eng_sys = default_channel
+            ch_distill_eng_sys = default_sheet
         }
 
         if (distill_ag == "1") {
             ch_distill_ag = file(params.distill_ag_sheet).exists() ? file(params.distill_ag_sheet) : error("Error: If using --distill_ecosystem ag, you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
 
         } else{
-            ch_distill_ag = default_channel
+            ch_distill_ag = default_sheet
         }
         /*
         if (params.distill_custom != "") {
             ch_distill_custom = file(params.distill_custom).exists() ? file(params.distill_custom) : error("Error: If using --distill_custom <path/to/TSV>, you must have the preformatted custom distill sheet in the provided file: ${params.distill_custom}.")
             distill_custom_list = "params.distill_custom"
         }else{
-            ch_distill_custom = default_channel
+            ch_distill_custom = default_sheet
         }
         */
         if (params.distill_custom != "") {
@@ -212,7 +212,7 @@ workflow DRAM {
             error "Error: The specified directory for merging annotations (--distill_custom) does not exist: ${params.distill_custom}"
         }
         else{
-            ch_distill_custom_collected = default_channel
+            ch_distill_custom_collected = default_sheet
         }
 
         // Verify the directory contains .tsv files
@@ -233,7 +233,7 @@ workflow DRAM {
         }
         }
         else{
-            ch_distill_custom_collected = default_channel
+            ch_distill_custom_collected = default_sheet
         }
 
     }
@@ -264,10 +264,10 @@ workflow DRAM {
     if (params.merge_annotations){
         MERGE()
     }else {
-        ch_quast_stats = default_channel
-        ch_gene_locs = default_channel
-        ch_called_proteins = default_channel
-        ch_collected_fna = default_channel
+        ch_quast_stats = default_sheet
+        ch_gene_locs = default_sheet
+        ch_called_proteins = default_sheet
+        ch_collected_fna = default_sheet
 
         if (params.call){
             CALL( ch_fasta )
@@ -283,7 +283,7 @@ workflow DRAM {
         }
 
         if (params.annotate){
-            ANNOTATE( ch_gene_locs, ch_called_proteins, default_channel )
+            ANNOTATE( ch_gene_locs, ch_called_proteins, default_sheet )
             
         }
         


### PR DESCRIPTION
when porting to nf-core style, bug introduced where annotations default sheet was treated as a channel when it wasn't before so some processes would treat it as a single item channel and then would only run the minimum of # of fasta or 1, which was 1 So only 1 fasta got ran.
Fixed this by changing it to not a channel, likt it was before the port.