### PR TITLE
Package/refactor for older nextflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -60,12 +60,11 @@ workflow {
     //
     PIPELINE_INITIALISATION (
         params.version,
+        params.help,
         params.validate_params,
         params.monochrome_logs,
         args,
         params.outdir,
-        params.input_fasta,
-        params.fasta_fmt
         // params.input
     )
 

--- a/modules.json
+++ b/modules.json
@@ -8,7 +8,9 @@
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -17,17 +19,23 @@
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "c2b22d85f30a706a3073387f30380704fcae013b",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "51ae5406a030d4da1e49e4dab49756844fdd6c7a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "2fd2cd6d0e7b273747f32e465fdc6bcc3ae0814e",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/local/add_and_combine/add_annotations.nf
+++ b/modules/local/add_and_combine/add_annotations.nf
@@ -3,6 +3,7 @@ process ADD_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_biopython:7df21d027f67112e"
 
     input:
     path( old_annotations, stageAs: "old_annotations.tsv" )

--- a/modules/local/add_and_combine/add_bin_quality.nf
+++ b/modules/local/add_and_combine/add_bin_quality.nf
@@ -3,6 +3,7 @@ process ADD_BIN_QUALITY {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_biopython:7df21d027f67112e"
 
     input:
     file( combined_annotations )

--- a/modules/local/add_and_combine/add_taxa.nf
+++ b/modules/local/add_and_combine/add_taxa.nf
@@ -3,6 +3,7 @@ process ADD_TAXA {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_biopython:7df21d027f67112e"
 
     input:
     file( combined_annotations )

--- a/modules/local/add_and_combine/count_annotations.nf
+++ b/modules/local/add_and_combine/count_annotations.nf
@@ -3,6 +3,7 @@ process COUNT_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_biopython:7df21d027f67112e"
     
     input:
     file( ch_combined_annotations )

--- a/modules/local/add_and_combine/generate_gff_genbank.nf
+++ b/modules/local/add_and_combine/generate_gff_genbank.nf
@@ -3,6 +3,7 @@ process GENERATE_GFF_GENBANK {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_biopython:7df21d027f67112e"
     
     input:
     val( all_genes_fna )

--- a/modules/local/annotate/add_sql_descriptions.nf
+++ b/modules/local/annotate/add_sql_descriptions.nf
@@ -3,6 +3,7 @@ process ADD_SQL_DESCRIPTIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     input:
     tuple val(input_fasta), path(hits_file)

--- a/modules/local/annotate/camper_hmm_formatter.nf
+++ b/modules/local/annotate/camper_hmm_formatter.nf
@@ -3,6 +3,7 @@ process CAMPER_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/canthyd_hmm_formatter.nf
+++ b/modules/local/annotate/canthyd_hmm_formatter.nf
@@ -3,6 +3,7 @@ process CANTHYD_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/combine_annotations.nf
+++ b/modules/local/annotate/combine_annotations.nf
@@ -3,6 +3,7 @@ process COMBINE_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     input:
     val all_annotations

--- a/modules/local/annotate/dbcan_hmm_formatter.nf
+++ b/modules/local/annotate/dbcan_hmm_formatter.nf
@@ -3,6 +3,7 @@ process DBCAN_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/fegenie_hmm_formatter.nf
+++ b/modules/local/annotate/fegenie_hmm_formatter.nf
@@ -3,6 +3,7 @@ process FEGENIE_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/gene_locs.nf
+++ b/modules/local/annotate/gene_locs.nf
@@ -3,6 +3,7 @@ process GENE_LOCS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/generic_hmm_formatter.nf
+++ b/modules/local/annotate/generic_hmm_formatter.nf
@@ -4,6 +4,7 @@ process GENERIC_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     input:
     path( hmm_info_path )

--- a/modules/local/annotate/hmmsearch.nf
+++ b/modules/local/annotate/hmmsearch.nf
@@ -3,6 +3,7 @@ process HMM_SEARCH {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/kegg_hmm_formatter.nf
+++ b/modules/local/annotate/kegg_hmm_formatter.nf
@@ -3,6 +3,7 @@ process KEGG_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/kofam_hmm_formatter.nf
+++ b/modules/local/annotate/kofam_hmm_formatter.nf
@@ -3,6 +3,7 @@ process KOFAM_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/merge_annotations.nf
+++ b/modules/local/annotate/merge_annotations.nf
@@ -3,6 +3,7 @@ process MERGE_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     input:
     path( ch_annotations, stageAs: "annotations/*" )

--- a/modules/local/annotate/mmseqs_index.nf
+++ b/modules/local/annotate/mmseqs_index.nf
@@ -3,6 +3,7 @@ process MMSEQS_INDEX{
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/mmseqs_search.nf
+++ b/modules/local/annotate/mmseqs_search.nf
@@ -3,6 +3,7 @@ process MMSEQS_SEARCH {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/parse_hmmsearch.nf
+++ b/modules/local/annotate/parse_hmmsearch.nf
@@ -3,6 +3,7 @@ process PARSE_HMM {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag{ input_fasta }
     

--- a/modules/local/annotate/sulfur_hmm_formatter.nf
+++ b/modules/local/annotate/sulfur_hmm_formatter.nf
@@ -3,6 +3,7 @@ process SULFUR_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/vog_hmm_formatter.nf
+++ b/modules/local/annotate/vog_hmm_formatter.nf
@@ -3,6 +3,7 @@ process VOG_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2:89f055454dac3575"
 
     tag { input_fasta }
 

--- a/modules/local/call/call_genes_prodigal.nf
+++ b/modules/local/call/call_genes_prodigal.nf
@@ -5,6 +5,7 @@ process CALL_GENES {
     tag { input_fasta }
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_scikit-bio_hmmer_pruned:ef64c488c99048d6"
 
     input:
     tuple val( input_fasta ), path( fasta )

--- a/modules/local/call/quast.nf
+++ b/modules/local/call/quast.nf
@@ -3,6 +3,7 @@ process QUAST {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_scikit-bio_hmmer_pruned:ef64c488c99048d6"
 
     input:
     path (collected_fasta_gff)

--- a/modules/local/call/quast_collect.nf
+++ b/modules/local/call/quast_collect.nf
@@ -3,6 +3,7 @@ process QUAST_COLLECT {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_scikit-bio_hmmer_pruned:ef64c488c99048d6"
 
     input:
     file quast_tsv_files

--- a/modules/local/collect_rna/environment.yml
+++ b/modules/local/collect_rna/environment.yml
@@ -5,4 +5,6 @@ channels:
 dependencies:
   - python=3.10
   - pandas=1.5.2
+  - barrnap=0.9
+  - trnascan-se=2.0.12
   

--- a/modules/local/collect_rna/rrna_collect.nf
+++ b/modules/local/collect_rna/rrna_collect.nf
@@ -3,6 +3,7 @@ process RRNA_COLLECT {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_barrnap_trnascan-se:ed2ab26abf39304b"
 
     input:
     file combined_rrnas

--- a/modules/local/collect_rna/rrna_scan.nf
+++ b/modules/local/collect_rna/rrna_scan.nf
@@ -3,6 +3,7 @@ process RRNA_SCAN {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_barrnap_trnascan-se:ed2ab26abf39304b"
 
     tag { input_fasta }
 

--- a/modules/local/collect_rna/trna_collect.nf
+++ b/modules/local/collect_rna/trna_collect.nf
@@ -5,6 +5,7 @@ process TRNA_COLLECT {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_barrnap_trnascan-se:ed2ab26abf39304b"
 
     input:
     file combined_trnas

--- a/modules/local/collect_rna/trna_scan.nf
+++ b/modules/local/collect_rna/trna_scan.nf
@@ -3,6 +3,7 @@ process TRNA_SCAN {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_barrnap_trnascan-se:ed2ab26abf39304b"
 
     tag { input_fasta }
 

--- a/modules/local/distill/distill.nf
+++ b/modules/local/distill/distill.nf
@@ -3,6 +3,7 @@ process DISTILL {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_pandas_openpyxl:20d9b4833f4ee53c"
 
     input:
     path( ch_combined_annotations, stageAs: "raw-annotations.tsv" )

--- a/modules/local/product/product_heatmap.nf
+++ b/modules/local/product/product_heatmap.nf
@@ -6,6 +6,7 @@ process PRODUCT_HEATMAP {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/python_dram-viz:8399ca59227b4fd9"
 
     input:
     path( ch_final_annots, stageAs: "raw-annotations.tsv")

--- a/modules/local/rename/environment.yml
+++ b/modules/local/rename/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bbmap

--- a/modules/local/rename/rename_fasta.nf
+++ b/modules/local/rename/rename_fasta.nf
@@ -2,6 +2,8 @@ process RENAME_FASTA {
 
     tag { "renaming_fastas" }
 
+    conda "${moduleDir}/environment.yml"
+
     input:
     val fasta_names
     path fastas

--- a/modules/local/rename/rename_fasta.nf
+++ b/modules/local/rename/rename_fasta.nf
@@ -3,6 +3,7 @@ process RENAME_FASTA {
     tag { "renaming_fastas" }
 
     conda "${moduleDir}/environment.yml"
+    container "community.wave.seqera.io/library/bbmap:801715ef64484762"
 
     input:
     val fasta_names

--- a/nextflow.config
+++ b/nextflow.config
@@ -405,7 +405,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.3.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.0.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {
@@ -413,7 +413,7 @@ validation {
     monochromeLogs = params.monochrome_logs
     help {
         enabled = true
-        command = "nextflow run WrightonLabCSU/dram -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
+        command = "nextflow run WrightonLabCSU/dram -profile <docker/singularity/.../institute> --input_fasta path/to/input_fasta <pipeline steps and options, --call, --annotate, etc.> --outdir path/to/outdir"
         fullParameter = "help_full"
         showHiddenParameter = "show_hidden"
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -4,7 +4,7 @@
     "title": "WrightonLabCSU/dram pipeline parameters",
     "description": "DRAM (Distilled and Refined Annotation of Metabolism) is a tool for annotating metagenomic assembled genomes",
     "type": "object",
-    "$defs": {
+    "defs": {
         "pipeline_steps": {
             "title": "Pipeline Steps",
             "type": "object",
@@ -59,18 +59,6 @@
                     "format": "directory-path",
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
-                },
-                "email": {
-                    "type": "string",
-                    "description": "Email address for completion summary.",
-                    "fa_icon": "fas fa-envelope",
-                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
-                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
-                },
-                "multiqc_title": {
-                    "type": "string",
-                    "description": "MultiQC report title. Printed as page header, used for filename if not otherwise specified.",
-                    "fa_icon": "fas fa-file-signature"
                 }
             }
         },
@@ -378,7 +366,6 @@
             "fa_icon": "fas fa-database",
             "description": "File paths to databases used in the workflow.",
             "properties": {
-
                 "kegg_db": {
                     "type": "string",
                     "default": "${launchDir}/databases/kegg/",
@@ -504,6 +491,56 @@
                     "type": "string",
                     "default": "${launchDir}/databases/db_descriptions/description_db.sqlite",
                     "hidden": true
+                },
+                "kegg_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "kofam_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "dbcan_e_value": {
+                    "type": "string",
+                    "default": "1e-15",
+                    "hidden": true
+                },
+                "merops_e_value": {
+                    "type": "string",
+                    "default": "1e-1",
+                    "hidden": true
+                },
+                "vog_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "camper_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "uniref_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "canthyd_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "sulfur_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
+                },
+                "fegenie_e_value": {
+                    "type": "string",
+                    "default": "1e-05",
+                    "hidden": true
                 }
             }
         },
@@ -589,6 +626,15 @@
                     ],
                     "hidden": true
                 },
+                "email": {
+                    "type": "string",
+                    "description": "Email address for completion summary.",
+                    "fa_icon": "fas fa-envelope",
+                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
+                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
+                    "hidden": true
+                },
+
                 "email_on_fail": {
                     "type": "string",
                     "description": "Email address for completion summary, only when pipeline fails.",
@@ -622,6 +668,12 @@
                     "description": "Incoming hook URL for messaging service",
                     "fa_icon": "fas fa-people-group",
                     "help_text": "Incoming hook URL for messaging service. Currently, MS Teams and Slack are supported.",
+                    "hidden": true
+                },
+                "multiqc_title": {
+                    "type": "string",
+                    "description": "MultiQC report title. Printed as page header, used for filename if not otherwise specified.",
+                    "fa_icon": "fas fa-file-signature",
                     "hidden": true
                 },
                 "multiqc_config": {
@@ -668,34 +720,37 @@
     },
     "allOf": [
         {
-            "$ref": "#/$defs/input_output_options"
+            "$ref": "#/defs/pipeline_steps"
         },
         {
-            "$ref": "#/$defs/genome_options"
+            "$ref": "#/defs/input_output_options"
         },
         {
-            "$ref": "#/$defs/call_prodigal_options"
+            "$ref": "#/defs/genome_options"
         },
         {
-            "$ref": "#/$defs/annotate_options"
+            "$ref": "#/defs/call_prodigal_options"
         },
         {
-            "$ref": "#/$defs/distill_options"
+            "$ref": "#/defs/annotate_options"
         },
         {
-            "$ref": "#/$defs/rna_options"
+            "$ref": "#/defs/distill_options"
         },
         {
-            "$ref": "#/$defs/bin_and_taxa_options"
+            "$ref": "#/defs/rna_options"
         },
         {
-            "$ref": "#/$defs/database_options"
+            "$ref": "#/defs/bin_and_taxa_options"
         },
         {
-            "$ref": "#/$defs/institutional_config_options"
+            "$ref": "#/defs/database_options"
         },
         {
-            "$ref": "#/$defs/generic_options"
+            "$ref": "#/defs/institutional_config_options"
+        },
+        {
+            "$ref": "#/defs/generic_options"
         },
         {
             "required": [

--- a/subworkflows/local/utils_pipeline_setup.nf
+++ b/subworkflows/local/utils_pipeline_setup.nf
@@ -1,3 +1,5 @@
+include { logColours           } from '../nf-core/utils_nfcore_pipeline'
+include { getWorkflowVersion           } from '../nf-core/utils_nfcore_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -20,3 +22,41 @@ def getFastaChannel(input_fasta, fasta_fmt) {
     }
     return ch_fasta  // channel: [ val(sample name), path(fasta) ]
 }
+
+//
+// DRAM logo
+//
+def dramLogo(monochrome_logs=true) {
+    Map colors = logColours(monochrome_logs)
+    String.format(  // In groovy we can use $/ to start a string to avoid escaping (end with /$)
+        $/\n
+        =====================================================================        
+                         _____    _____               __  __            
+        (==(     )==)   |  __ \  |  __ \      /\     |  \/  |   (==(     )==)    
+         `-.`. ,',-'    | |  | | | |__) |    /  \    | \  / |    `-.`. ,',-'     
+            _,-'"       | |  | | |  _  /    / /\ \   | |\/| |       _,-'"        
+         ,-',' `.`-.    | |__| | | | \ \   / ____ \  | |  | |    ,-',' `.`-.     
+        (==(     )==)   |_____/  |_|  \_\ /_/    \_\ |_|  |_|   (==(     )==)    
+                                            
+        =====================================================================
+        /$.stripIndent()  // end the string with /$ to avoid escaping
+    )
+}
+
+//
+// Citation string for pipeline  TODO: finish citation information
+//
+def workflowCitation() {
+    def temp_doi_ref = ""
+    String[] manifest_doi = workflow.manifest.doi.tokenize(",")
+    // Using a loop to handle multiple DOIs
+    // Removing `https://doi.org/` to handle pipelines using DOIs vs DOI resolvers
+    // Removing ` ` since the manifest.doi is a string and not a proper list
+    for (String doi_ref: manifest_doi) temp_doi_ref += "  https://doi.org/${doi_ref.replace('https://doi.org/', '').replace(' ', '')}\n"
+    return "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
+        "* DRAM\n" +
+        temp_doi_ref + "\n" +
+        // "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
+        "* Software dependencies\n" +
+        "  https://github.com/${workflow.manifest.name}/blob/master/CITATIONS.md"
+}  // TODO add DOI for DRAM


### PR DESCRIPTION
- [downgrade nf-schema to 2.0.1 so nextflow can be down to 23 or even 22…](https://github.com/WrightonLabCSU/DRAM/commit/2033031709749b4e532cc40daa2448a0035425d0) 
… something so known users stuck on 23.something can use DRAM 2
- [Update rename for dependencies](https://github.com/WrightonLabCSU/DRAM/commit/e7a61a562638635716b53a9a7fe5198fad87a83e)
- [Update modules code to include wave seqera container](https://github.com/WrightonLabCSU/DRAM/commit/cc9b372f1aae59fa94aabcef3944d4d37e6077e2) 
using wave-cli, with cmd
for every module in modules/local, then adding the outputted url to
container outputer.url for the modules nextflow script, under the conda line.
This allows users to not just use conda, but also containers, and we don't have to build them
Ideally this would be added to a CI, but I haven't see where nf-core is doing that with a CI yet.
This is needed since not all out users can easily use conda.