### PR TITLE
Bugfix/merops in distill not correct

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,674 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) Micobial Ecosystems Lab, Colorado State University Fort Collins
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/bin/adjectives.py
+++ b/bin/adjectives.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 """Contains main entry point to the program and helper functions"""
 import os
+import ast
 import click
 
 import pandas as pd
 
 from rule_adjectives.rule_graph import RuleParser, get_positive_genes
 from rule_adjectives.annotations import Annotations
+from utils.click_utils import validate_comma_separated
 
 
 class PythonLiteralOption(click.Option):
@@ -53,12 +55,7 @@ def show_rules_path(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
     print(get_package_path('rules.tsv'))
-    
-def validate_comma_separated(ctx, param, value):
-    print(value)
-    if not value:
-        return []
-    return value.split(',')
+
 
 @click.command()
 @click.option('--annotations', type=click.Path(exists=True), required=True, help="One of only 2 required files. Path to a DRAM annotations file.")

--- a/bin/combine_annotations.py
+++ b/bin/combine_annotations.py
@@ -85,7 +85,7 @@ def combine_annotations(annotation_files, output_file, threads, genes_faa=None):
         df.index.name = 'query_id'
         logging.info(df)
         
-        combined_data = pd.merge(combined_data, df, how="inner", on="query_id")
+        combined_data = pd.merge(combined_data, df, how="left", on="query_id")
                 
     combined_data = convert_bit_scores_to_numeric(combined_data)
     

--- a/bin/distill.py
+++ b/bin/distill.py
@@ -1,0 +1,769 @@
+"""This is the script that distills the genomes"""
+import logging
+from collections import Counter
+from itertools import chain
+import pandas as pd
+from collections import Counter, defaultdict
+from os import path, mkdir
+import altair as alt
+import networkx as nx
+from itertools import tee
+import re
+import numpy as np
+from datetime import datetime
+import click
+
+from mag_annotator.database_handler import DatabaseHandler
+from mag_annotator.utils import get_ordered_uniques, setup_logger
+from mag_annotator.camper_kit import NAME as CAMPER_NAME
+
+# TODO: add RBH information to output
+# TODO: add flag to output table and not xlsx
+# TODO: add flag to output heatmap table
+
+FRAME_COLUMNS = ['gene_id', 'gene_description', 'module', 'sheet', 'header', 'subheader']
+RRNA_TYPES = ['5S rRNA', '16S rRNA', '23S rRNA']
+HEATMAP_MODULES = ['M00001', 'M00004', 'M00008', 'M00009', 'M00012', 'M00165', 'M00173',
+                   'M00374', 'M00375', 'M00376', 'M00377', 'M00422', 'M00567']
+HEATMAP_CELL_HEIGHT = 10
+HEATMAP_CELL_WIDTH = 10
+KO_REGEX = r'^K\d\d\d\d\d$'
+ETC_COVERAGE_COLUMNS = ['module_id', 'module_name', 'complex', 'genome', 'path_length',
+                        'path_length_coverage', 'percent_coverage', 'genes', 'missing_genes',
+                        'complex_module_name']
+TAXONOMY_LEVELS = ['d', 'p', 'c', 'o', 'f', 'g', 's']
+COL_HEADER, COL_SUBHEADER, COL_MODULE, COL_GENE_ID, COL_GENE_DESCRIPTION = 'header', 'subheader', 'module', 'gene_id', 'gene_description'
+CONSTANT_DISTILLATE_COLUMNS = [COL_GENE_ID, COL_GENE_DESCRIPTION, COL_MODULE, COL_HEADER, COL_SUBHEADER]
+DISTILATE_SORT_ORDER_COLUMNS = [COL_HEADER, COL_SUBHEADER, COL_MODULE, COL_GENE_ID]
+EXCEL_MAX_CELL_SIZE = 32767
+
+ID_FUNCTION_DICT = {
+    'kegg_genes_id': lambda x: [x],
+    'ko_id': lambda x: [j for j in x.split(',')],
+    'kegg_id': lambda x: [j for j in x.split(',')],
+    'kegg_hit': lambda x: [i[1:-1] for i in
+                           re.findall(r'\[EC:\d*.\d*.\d*.\d*\]', x)],
+    'peptidase_family': lambda x: [j for j in x.split(';')],
+    'cazy_best_hit': lambda x: [x.split('_')[0]],
+    'pfam_hits': lambda x: [j[1:-1].split('.')[0]
+                            for j in re.findall(r'\[PF\d\d\d\d\d.\d*\]', x)],
+    'camper_id': lambda x: [x],
+    'fegenie_id': lambda x: [x],
+    'sulfur_id': lambda x: [x],
+    'methyl_id': lambda x: [i.split(' ')[0].strip() for i in x.split(',')]
+}
+
+
+def check_columns(data, logger):
+    functions = {i:j for i,j in ID_FUNCTION_DICT.items() if i in data.columns}
+    missing = [i for i in ID_FUNCTION_DICT if i not in data.columns]
+    logger.info("Note: the fallowing id fields "
+          f"were not in the annotations file and are not being used: {missing},"
+          f" but these are {list(functions.keys())}")
+
+
+def get_ids_from_annotations_by_row(data):
+    functions = {i:j for i,j in ID_FUNCTION_DICT.items() if i in data.columns}
+    out = data.apply(lambda x: {i for k, v in functions.items() if not pd.isna(x[k])
+                          for i in v(str(x[k])) if not pd.isna(i)}, axis=1)
+    return out
+
+
+def get_ids_from_annotations_all(data):
+    data =  get_ids_from_annotations_by_row(data)
+    data.apply(list)
+    out = Counter(chain(*data.values))
+    return out
+
+
+def fill_genome_summary_frame(annotations, genome_summary_frame, groupby_column, logger):
+    genome_summary_id_sets = [set([str(k).strip() for k in j.split(',')]) for j in genome_summary_frame['gene_id']]
+    
+    def fill_a_frame(frame: pd.DataFrame):
+        id_dict = get_ids_from_annotations_all(frame)
+        
+        counts = list()
+        for i in genome_summary_id_sets:
+            identifier_count = 0
+            for j in i:
+                # Try matching with and without '.hmm'
+                matching_keys = [key for key in id_dict.keys() if j == key or key.startswith(j + ".")]
+                for key in matching_keys:
+                    identifier_count += id_dict[key]
+            counts.append(identifier_count)
+        
+        return pd.Series(counts, index=genome_summary_frame.index)
+    
+    counts = annotations.groupby(groupby_column, sort=False).apply(fill_a_frame)
+    genome_summary_frame = pd.concat([genome_summary_frame, counts.T], axis=1)
+    
+    return genome_summary_frame
+
+
+def fill_genome_summary_frame_gene_names(annotations, genome_summary_frame, groupby_column, logger):
+    genome_summary_id_sets = [set([k.strip() for k in j.split(',')]) for j in genome_summary_frame['gene_id']]
+    for genome, frame in annotations.groupby(groupby_column, sort=False):
+        # make dict of identifiers to gene names
+        id_gene_dict = defaultdict(list)
+        for gene, ids in get_ids_from_annotations_by_row(frame).items():
+            for id_ in ids:
+                id_gene_dict[id_].append(gene)
+        # fill in genome summary_frame
+        values = list()
+        for id_set in genome_summary_id_sets:
+            this_value = list()
+            for id_ in id_set:
+                this_value += id_gene_dict[id_]
+            values.append(','.join(this_value))
+        genome_summary_frame[genome] = values
+    return genome_summary_frame
+
+
+def summarize_rrnas(rrnas_df, groupby_column='fasta'):
+    genome_rrna_dict = dict()
+    for genome, frame in rrnas_df.groupby(groupby_column):
+        genome_rrna_dict[genome] = Counter(frame['type'])
+    row_list = list()
+    for rna_type in RRNA_TYPES:
+        row = [rna_type, '%s ribosomal RNA gene' % rna_type.split()[0], 'rRNA', 'rRNA', '', '']
+        for genome, rrna_dict in genome_rrna_dict.items():
+            row.append(genome_rrna_dict[genome].get(rna_type, 0))
+        row_list.append(row)
+    rrna_frame = pd.DataFrame(row_list, columns=FRAME_COLUMNS + list(genome_rrna_dict.keys()))
+    return rrna_frame
+
+
+def summarize_trnas(trnas_df, groupby_column='fasta'):
+    # first build the frame
+    combos = {(line.Type, line.Codon, line.Note) for _, line in trnas_df.iterrows()}
+    frame_rows = list()
+    for combo in combos:
+        if combo[2] == 'pseudo':
+            gene_id = '%s, pseudo (%s)'
+            gene_description = '%s pseudo tRNA with %s Codon'
+        else:
+            gene_id = '%s (%s)'
+            gene_description = '%s tRNA with %s Codon'
+        gene_id = gene_id % (combo[0], combo[1])
+        gene_description = gene_description % (combo[0], combo[1])
+        module_description = '%s tRNA' % combo[0]
+        frame_rows.append([gene_id, gene_description, module_description, 'tRNA', 'tRNA', ''])
+    trna_frame = pd.DataFrame(frame_rows, columns=FRAME_COLUMNS)
+    trna_frame = trna_frame.sort_values('gene_id')
+    # then fill it in
+    trna_frame = trna_frame.set_index('gene_id')
+    for group, frame in trnas_df.groupby(groupby_column):
+        gene_ids = list()
+        for index, line in frame.iterrows():
+            if line.Note == 'pseudo':
+                gene_id = '%s, pseudo (%s)'
+            else:
+                gene_id = '%s (%s)'
+            gene_ids.append(gene_id % (line.Type, line.Codon))
+        trna_frame[group] = pd.Series(Counter(gene_ids))
+    trna_frame = trna_frame.reset_index()
+    trna_frame = trna_frame.fillna(0)
+    return trna_frame
+
+
+def make_genome_summary(annotations, genome_summary_frame, logger, trna_frame=None, rrna_frame=None, groupby_column='fasta'):
+    summary_frames = list()
+    # get ko summaries
+    summary_frames.append(fill_genome_summary_frame(annotations, genome_summary_frame.copy(), groupby_column, logger))
+
+    # add rRNAs
+    if rrna_frame is not None:
+        summary_frames.append(summarize_rrnas(rrna_frame, groupby_column))
+
+    # add tRNAs
+    if trna_frame is not None:
+        summary_frames.append(summarize_trnas(trna_frame, groupby_column))
+
+    # merge summary frames
+    summarized_genomes = pd.concat(summary_frames, sort=False)
+    return summarized_genomes
+
+
+def split_column_str(names):
+    if len(names) < EXCEL_MAX_CELL_SIZE:
+        return [names]
+    out = ['']
+    name_list = names.split(',')
+    j = 0
+    for i in name_list:
+        if len(out[j]) + len(i) + 1 < EXCEL_MAX_CELL_SIZE:
+            out[j] = ','.join([out[j], i])
+        else:
+            j += 1
+            out += ['']
+    return out
+
+
+def split_names_to_long(col:pd.Series):
+    dex = col.index
+    splits = [split_column_str(i) for i in col.values]
+    ncols =  max([len(i) for i in splits])
+    col_names = [col.name if i == 0 else f"{col.name}[{i + 1}]" for i in range(ncols)]
+    return pd.DataFrame(splits, columns=col_names, index=dex).fillna('')
+
+
+def write_summarized_genomes_to_xlsx(summarized_genomes, output_file):
+    # turn all this into an xlsx
+    with pd.ExcelWriter(output_file) as writer:
+        for sheet, frame in summarized_genomes.groupby('sheet', sort=False):
+            frame = frame.sort_values(DISTILATE_SORT_ORDER_COLUMNS)
+            frame = frame.drop(['sheet'], axis=1)
+            gene_columns = list(set(frame.columns) - set(CONSTANT_DISTILLATE_COLUMNS))
+            split_genes = pd.concat([split_names_to_long(frame[i].astype(str)) for i in gene_columns], axis=1)
+            frame = pd.concat([frame[CONSTANT_DISTILLATE_COLUMNS],  split_genes], axis=1)
+            frame.to_excel(writer, sheet_name=sheet, index=False)
+
+
+# TODO: add assembly stats like N50, longest contig, total assembled length etc
+def make_genome_stats(annotations, rrna_frame=None, trna_frame=None, groupby_column='fasta'):
+    rows = list()
+    columns = ['genome']
+    if 'scaffold' in annotations.columns:
+        columns.append('number of scaffolds')
+    if 'bin_taxonomy' in annotations.columns:
+        columns.append('taxonomy')
+    if 'bin_completeness' in annotations.columns:
+        columns.append('completeness score')
+    if 'bin_contamination' in annotations.columns:
+        columns.append('contamination score')
+    if rrna_frame is not None:
+        columns += RRNA_TYPES
+    if trna_frame is not None:
+        columns.append('tRNA count')
+    if 'bin_completeness' in annotations.columns and 'bin_contamination' in annotations.columns \
+       and rrna_frame is not None and trna_frame is not None:
+        columns.append('assembly quality')
+    for genome, frame in annotations.groupby(groupby_column, sort=False):
+        row = [genome]
+        if 'scaffold' in frame.columns:
+            row.append(len(set(frame['scaffold'])))
+        if 'bin_taxonomy' in frame.columns:
+            row.append(frame['bin_taxonomy'][0])
+        if 'bin_completeness' in frame.columns:
+            row.append(frame['bin_completeness'][0])
+        if 'bin_contamination' in frame.columns:
+            row.append(frame['bin_contamination'][0])
+        has_rrna = list()
+        if rrna_frame is not None:
+            genome_rrnas = rrna_frame.loc[rrna_frame.fasta == genome]
+            for rrna in RRNA_TYPES:
+                sixteens = genome_rrnas.loc[genome_rrnas.type == rrna]
+                if sixteens.shape[0] == 0:
+                    row.append('')
+                    has_rrna.append(False)
+                elif sixteens.shape[0] == 1:
+                    row.append('%s (%s, %s)' % (sixteens['scaffold'].iloc[0], sixteens.begin.iloc[0],
+                                                sixteens.end.iloc[0]))
+                    has_rrna.append(True)
+                else:
+                    row.append('%s present' % sixteens.shape[0])
+                    has_rrna.append(False)
+        if trna_frame is not None:
+            # TODO: remove psuedo from count?
+            row.append(trna_frame.loc[trna_frame[groupby_column] == genome].shape[0])
+        if 'assembly quality' in columns:
+            if frame['bin_completeness'][0] > 90 and frame['bin_contamination'][0] < 5 and np.all(has_rrna) and \
+               len(set(trna_frame.loc[trna_frame[groupby_column] == genome].Type)) >= 18:
+                row.append('high')
+            elif frame['bin_completeness'][0] >= 50 and frame['bin_contamination'][0] < 10:
+                row.append('med')
+            else:
+                row.append('low')
+        rows.append(row)
+    genome_stats = pd.DataFrame(rows, columns=columns)
+    return genome_stats
+
+
+def build_module_net(module_df):
+    """Starts with a data from including a single module"""
+    # build net from a set of module paths
+    num_steps = max([int(i.split(',')[0]) for i in set(module_df['path'])])
+    module_net = nx.DiGraph(num_steps=num_steps, module_id=list(module_df['module'])[0],
+                            module_name=list(module_df['module_name'])[0])
+    # go through all path/step combinations
+    for module_path, frame in module_df.groupby('path'):
+        split_path = [int(i) for i in module_path.split(',')]
+        step = split_path[0]
+        module_net.add_node(module_path, kos=set(frame['ko']))
+        # add incoming edge
+        if step != 0:
+            module_net.add_edge('end_step_%s' % (step - 1), module_path)
+        # add outgoing edge
+        module_net.add_edge(module_path, 'end_step_%s' % step)
+    return module_net
+
+
+def get_module_step_coverage(kos, module_net):
+    # prune network based on what kos were observed
+    pruned_module_net = module_net.copy()
+    module_kos_present = set()
+    for node, data in module_net.nodes.items():
+        if 'kos' in data:
+            ko_overlap = data['kos'] & kos
+            if len(ko_overlap) == 0:
+                pruned_module_net.remove_node(node)
+            else:
+                module_kos_present = module_kos_present | ko_overlap
+    # count number of missing steps
+    missing_steps = 0
+    for node, data in pruned_module_net.nodes.items():
+        if ('end_step' in node) and (pruned_module_net.in_degree(node) == 0):
+            missing_steps += 1
+    # get statistics
+    num_steps = pruned_module_net.graph['num_steps'] + 1
+    num_steps_present = num_steps - missing_steps
+    coverage = num_steps_present / num_steps
+    return num_steps, num_steps_present, coverage, sorted(module_kos_present)
+
+
+def make_module_coverage_df(annotation_df, module_nets):
+    kos_to_genes = defaultdict(list)
+    ko_id_name = 'kegg_id' if 'kegg_id' in annotation_df.columns else 'ko_id'
+    for gene_id, ko_list in annotation_df[ko_id_name].items():
+        if type(ko_list) is str:
+            for ko in ko_list.split(','):
+                kos_to_genes[ko].append(gene_id)
+    coverage_dict = {}
+    for i, (module, net) in enumerate(module_nets.items()):
+        module_steps, module_steps_present, module_coverage, module_kos = \
+            get_module_step_coverage(set(kos_to_genes.keys()), net)
+        module_genes = sorted([gene for ko in module_kos for gene in kos_to_genes[ko]])
+        coverage_dict[module] = [net.graph['module_name'], module_steps, module_steps_present, module_coverage,
+                                 len(module_kos), ','.join(module_kos), ','.join(module_genes)]
+    coverage_df = pd.DataFrame.from_dict(coverage_dict, orient='index',
+                                         columns=['module_name', 'steps', 'steps_present', 'step_coverage', 'ko_count',
+                                                  'kos_present', 'genes_present'])
+    return coverage_df
+
+
+def make_module_coverage_frame(annotations, module_nets, groupby_column='fasta'):
+    # go through each scaffold to check for modules
+    module_coverage_dict = dict()
+    for group, frame in annotations.groupby(groupby_column, sort=False):
+        module_coverage_dict[group] = make_module_coverage_df(frame, module_nets)
+    module_coverage = pd.concat(module_coverage_dict)
+    module_coverage.index = module_coverage.index.set_names(['genome', 'module'])
+    return module_coverage.reset_index()
+
+
+def make_module_coverage_heatmap(module_coverage, mag_order=None):
+    num_mags_in_frame = len(set(module_coverage['genome']))
+    c = alt.Chart(module_coverage, title='Module').encode(
+        x=alt.X('module_name', title=None, sort=None, axis=alt.Axis(labelLimit=0, labelAngle=90)),
+        y=alt.Y('genome', title=None, sort=mag_order, axis=alt.Axis(labelLimit=0)),
+        tooltip=[alt.Tooltip('genome', title='Genome'),
+                 alt.Tooltip('module_name', title='Module Name'),
+                 alt.Tooltip('steps', title='Module steps'),
+                 alt.Tooltip('steps_present', title='Steps present')
+                 ]
+    ).mark_rect().encode(color=alt.Color('step_coverage', legend=alt.Legend(title='% Complete'),
+                                         scale=alt.Scale(domain=(0, 1)))).properties(
+        width=HEATMAP_CELL_WIDTH * len(HEATMAP_MODULES),
+        height=HEATMAP_CELL_HEIGHT * num_mags_in_frame)
+    return c
+
+
+def pairwise(iterable):
+    """s -> (s0,s1), (s1,s2), (s2, s3), ..."""
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+def first_open_paren_is_all(str_):
+    """Go through string and return true"""
+    curr_level = 1
+    for char in str_[1:-1]:
+        if char == ')':
+            curr_level -= 1
+        elif char == '(':
+            curr_level += 1
+        if curr_level == 0:
+            return False
+    return True
+
+
+def split_into_steps(definition, split_char=' '):
+    """Very fancy split on string of chars"""
+    curr_level = 0
+    step_starts = [-1]
+    for i, char in enumerate(definition):
+        if char == '(':
+            curr_level += 1
+        if char == ')':
+            curr_level -= 1
+        if (curr_level == 0) and (char in split_char):
+            step_starts.append(i)
+    step_starts.append(len(definition))
+    steps = list()
+    for a, b in pairwise(step_starts):
+        step = definition[a+1:b]
+        if step.startswith('(') and step.endswith(')'):
+            if first_open_paren_is_all(step):
+                step = step[1:-1]
+        steps.append(step)
+    return steps
+
+
+def is_ko(ko):
+    return re.match(KO_REGEX, ko) is not None
+
+
+def make_module_network(definition, network: nx.DiGraph = None, parent_nodes=('start',)):
+    # TODO: Figure out how to add 'end' step to last step at end
+    if network is None:
+        network = nx.DiGraph()
+    last_steps = []
+    for step in split_into_steps(definition, ','):
+        prev_steps = parent_nodes
+        for substep in split_into_steps(step, '+'):
+            if is_ko(substep):
+                for prev_step in prev_steps:
+                    network.add_edge(prev_step, substep)
+                prev_steps = [substep]
+            else:
+                network, prev_steps = make_module_network(substep, network, prev_steps)
+        last_steps += prev_steps
+    return network, last_steps
+
+
+def get_module_coverage(module_net: nx.DiGraph, genes_present: set):
+    max_coverage = -1
+    max_coverage_genes = list()
+    max_coverage_missing_genes = list()
+    max_path_len = 0
+    for net_path in nx.all_simple_paths(module_net, source='start', target='end'):
+        net_path = set(net_path[1:-1])
+        overlap = net_path & genes_present
+        coverage = len(overlap) / len(net_path)
+        if coverage > max_coverage:
+            max_coverage = coverage
+            max_coverage_genes = overlap
+            max_coverage_missing_genes = net_path - genes_present
+            max_path_len = len(net_path)
+    return max_path_len, len(max_coverage_genes), max_coverage, max_coverage_genes, max_coverage_missing_genes
+
+
+def make_etc_coverage_df(etc_module_df, annotations, groupby_column='fasta'):
+    etc_coverage_df_rows = list()
+    for _, module_row in etc_module_df.iterrows():
+        definition = module_row['definition']
+        # remove optional subunits
+        definition = re.sub(r'-K\d\d\d\d\d', '', definition)
+        module_net, _ = make_module_network(definition)
+        # add end node
+        no_out = [node for node in module_net.nodes() if module_net.out_degree(node) == 0]
+        for node in no_out:
+            module_net.add_edge(node, 'end')
+        # go through each genome and check pathway coverage
+        for group, frame in annotations.groupby(groupby_column):
+            # get annotation genes
+            grouped_ids = set(get_ids_from_annotations_all(frame).keys())
+            path_len, path_coverage_count, path_coverage_percent, genes, missing_genes = \
+                get_module_coverage(module_net, grouped_ids)
+            complex_module_name = 'Complex %s: %s' % (module_row['complex'].replace('Complex ', ''),
+                                                      module_row['module_name'])
+            etc_coverage_df_rows.append([module_row['module_id'], module_row['module_name'],
+                                         module_row['complex'].replace('Complex ', ''), group, path_len,
+                                         path_coverage_count, path_coverage_percent, ','.join(sorted(genes)),
+                                         ','.join(sorted(missing_genes)), complex_module_name])
+    return pd.DataFrame(etc_coverage_df_rows, columns=ETC_COVERAGE_COLUMNS)
+
+
+def make_etc_coverage_heatmap(etc_coverage, mag_order=None, module_order=None):
+    num_mags_in_frame = len(set(etc_coverage['genome']))
+    charts = list()
+    for i, (etc_complex, frame) in enumerate(etc_coverage.groupby('complex')):
+        # if this is the first chart then make y-ticks otherwise none
+        c = alt.Chart(frame, title=etc_complex).encode(
+            x=alt.X('module_name', title=None, axis=alt.Axis(labelLimit=0, labelAngle=90),
+                    sort=module_order),
+            y=alt.Y('genome', axis=alt.Axis(title=None, labels=False, ticks=False), sort=mag_order),
+            tooltip=[alt.Tooltip('genome', title='Genome'),
+                     alt.Tooltip('module_name', title='Module Name'),
+                     alt.Tooltip('path_length', title='Module Subunits'),
+                     alt.Tooltip('path_length_coverage', title='Subunits present'),
+                     alt.Tooltip('genes', title='Genes present'),
+                     alt.Tooltip('missing_genes', title='Genes missing')
+                     ]
+        ).mark_rect().encode(color=alt.Color('percent_coverage', legend=alt.Legend(title='% Complete'),
+                                             scale=alt.Scale(domain=(0, 1)))).properties(
+            width=HEATMAP_CELL_WIDTH * len(set(frame['module_name'])),
+            height=HEATMAP_CELL_HEIGHT * num_mags_in_frame)
+        charts.append(c)
+    concat_title = alt.TitleParams('ETC Complexes', anchor='middle')
+    return alt.hconcat(*charts, spacing=5, title=concat_title)
+
+
+def make_functional_df(annotations, function_heatmap_form, logger, groupby_column='fasta'):
+    # clean up function heatmap form
+    function_heatmap_form = function_heatmap_form.apply(lambda x: x.str.strip() if x.dtype == "object" else x)
+    function_heatmap_form = function_heatmap_form.fillna('')
+    # build dict of ids per genome
+    genome_to_id_dict = dict()
+    for genome, frame in annotations.groupby(groupby_column, sort=False):
+        id_list = get_ids_from_annotations_all(frame).keys()
+        genome_to_id_dict[genome] = set(id_list)
+    # build long from data frame
+    rows = list()
+    for function, frame in function_heatmap_form.groupby('function_name', sort=False):
+        for bin_name, id_set in genome_to_id_dict.items():
+            presents_in_bin = list()
+            functions_present = set()
+            for _, row in frame.iterrows():
+                function_id_set = set([i.strip() for i in row.function_ids.strip().split(',')])
+                present_in_bin = id_set & function_id_set
+                functions_present = functions_present | present_in_bin
+                presents_in_bin.append(len(present_in_bin) > 0)
+            function_in_bin = np.all(presents_in_bin)
+            row = frame.iloc[0]
+            rows.append([row.category, row.subcategory, row.function_name, ', '.join(functions_present),
+                         '; '.join(get_ordered_uniques(frame.long_function_name)),
+                         '; '.join(get_ordered_uniques(frame.gene_symbol)), bin_name, function_in_bin,
+                         '%s: %s' % (row.category, row.function_name)])
+    return pd.DataFrame(rows, columns=list(function_heatmap_form.columns) + ['genome', 'present',
+                                                                             'category_function_name'])
+
+
+def make_functional_heatmap(functional_df, mag_order=None):
+    # build heatmaps
+    charts = list()
+    for i, (group, frame) in enumerate(functional_df.groupby('category', sort=False)):
+        # set variables for chart
+        function_order = get_ordered_uniques(list(frame.function_name))
+        num_mags_in_frame = len(set(frame['genome']))
+        chart_width = HEATMAP_CELL_WIDTH * len(function_order)
+        chart_height = HEATMAP_CELL_HEIGHT * num_mags_in_frame
+        # if this is the first chart then make y-ticks otherwise none
+        if i == 0:
+            y = alt.Y('genome', title=None, sort=mag_order,
+                      axis=alt.Axis(labelLimit=0, labelExpr="replace(datum.label, /_\d*$/gi, '')"))
+        else:
+            y = alt.Y('genome', axis=alt.Axis(title=None, labels=False, ticks=False), sort=mag_order)
+        # set up colors for chart
+        rect_colors = alt.Color('present',
+                                legend=alt.Legend(title="Function is Present", symbolType='square',
+                                                  values=[True, False]),
+                                sort=[True, False],
+                                scale=alt.Scale(range=['#2ca25f', '#e5f5f9']))
+        # define chart
+        # TODO: Figure out how to angle title to take up less space
+        c = alt.Chart(frame, title=alt.TitleParams(group)).encode( x=alt.X('function_name', title=None, axis=alt.Axis(labelLimit=0, labelAngle=90), sort=function_order), tooltip=[alt.Tooltip('genome', title='Genome'), alt.Tooltip('category', title='Category'), alt.Tooltip('subcategory', title='Subcategory'), alt.Tooltip('function_ids', title='Function IDs'), alt.Tooltip('function_name', title='Function'), alt.Tooltip('long_function_name', title='Description'), alt.Tooltip('gene_symbol', title='Gene Symbol')]).mark_rect().encode(y=y, color=rect_colors).properties( width=chart_width, height=chart_height)
+        charts.append(c)
+    # merge and return
+    function_heatmap = alt.hconcat(*charts, spacing=5)
+    return function_heatmap
+
+
+# TODO: refactor this to handle splitting large numbers of genomes into multiple heatmaps here
+def fill_liquor_dfs(annotations, module_nets, etc_module_df, function_heatmap_form, logger, groupby_column='fasta'):
+    module_coverage_frame = make_module_coverage_frame(annotations, module_nets, groupby_column)
+
+    # make ETC frame
+    etc_coverage_df = make_etc_coverage_df(etc_module_df, annotations, groupby_column)
+
+    # make functional frame
+    function_df = make_functional_df(annotations, function_heatmap_form, logger, groupby_column)
+
+    return module_coverage_frame, etc_coverage_df, function_df
+
+
+def rename_genomes_to_taxa(function_df, labels, mag_order):
+    function_df = function_df.copy()
+    new_genome_column = [labels[i] for i in function_df['genome']]
+    function_df['genome'] = pd.Series(new_genome_column, index=function_df.index)
+    mag_order = [labels[i] for i in mag_order]
+    return function_df, mag_order
+
+
+def make_liquor_heatmap(module_coverage_frame, etc_coverage_df, function_df, mag_order=None, labels=None):
+    module_coverage_heatmap = make_module_coverage_heatmap(module_coverage_frame, mag_order)
+    etc_heatmap = make_etc_coverage_heatmap(etc_coverage_df, mag_order=mag_order)
+    if labels is not None:
+        function_df, mag_order = rename_genomes_to_taxa(function_df, labels, mag_order)
+    function_heatmap = make_functional_heatmap(function_df, mag_order)
+
+    liquor = alt.hconcat(alt.hconcat(module_coverage_heatmap, etc_heatmap), function_heatmap)
+    return liquor
+
+
+def make_liquor_df(module_coverage_frame, etc_coverage_df, function_df):
+    liquor_df = pd.concat([module_coverage_frame.pivot(index='genome', columns='module_name', values='step_coverage'),
+                           etc_coverage_df.pivot(index='genome', columns='complex_module_name',
+                                                 values='percent_coverage'),
+                           function_df.pivot(index='genome', columns='category_function_name', values='present')],
+                          axis=1, sort=False)
+    return liquor_df
+
+
+def get_phylum_and_most_specific(taxa_str):
+    taxa_ranks = [i[3:] for i in taxa_str.split(';')]
+    phylum = taxa_ranks[1]
+    most_specific_rank = TAXONOMY_LEVELS[sum([len(i) > 0 for i in taxa_ranks])-1]
+    most_specific_taxa = taxa_ranks[sum([len(i) > 0 for i in taxa_ranks]) - 1]
+    if most_specific_rank == 'd':
+        return 'd__%s;p__' % most_specific_taxa
+    if most_specific_rank == 'p':
+        return 'p__%s;c__' % most_specific_taxa
+    else:
+        return 'p__%s;%s__%s' % (phylum, most_specific_rank, most_specific_taxa)
+
+
+def make_strings_no_repeats(genome_taxa_dict):
+    labels = dict()
+    seen = Counter()
+    for genome, taxa_string in genome_taxa_dict.items():
+        final_taxa_string = '%s_%s' % (taxa_string, str(seen[taxa_string]))
+        seen[taxa_string] += 1
+        labels[genome] = final_taxa_string
+    return labels
+
+
+@click.command()
+@click.option("-i", "--input_file", required=True, help="Annotations path")
+@click.option("-o", "--output_dir", required=True, help="Directory to write summarized genomes")
+@click.option('--log_file_path', 
+                                    help="A name and loctation for the log file")
+@click.option("--rrna_path", help="rRNA output from annotation")
+@click.option("--trna_path", help="tRNA output from annotation")
+@click.option("--groupby_column", help="Column from annotations to group as organism units",
+                            default='fasta')
+@click.option('--config_loc', default=None,
+                            help='location of an alternive config file that will over write the original at run time,'
+                            ' but not be saved or modified')
+@click.option("--custom_distillate", help="Custom distillate form to add your own modules")
+@click.option("--distillate_gene_names", action='store_true', default=False,
+                            help="Give names of genes instead of counts in genome metabolism summary")
+def distill(input_file, trna_path=None, rrna_path=None, output_dir='.',
+                      groupby_column='fasta', log_file_path=None, custom_distillate=None,
+                      distillate_gene_names=False, genomes_per_product=1000, config_loc=None):
+    """Summarize metabolic content of annotated genomes"""
+    # make output folder
+    mkdir(output_dir)
+    if log_file_path is None:
+        log_file_path = path.join(output_dir, "distill.log")
+    logger = logging.getLogger('distillation_log')
+    setup_logger(logger, log_file_path)
+    logger.info(f"The log file is created at {log_file_path}")
+
+    # read in data
+    annotations = pd.read_csv(input_file, sep='\t', index_col=0)
+    if 'bin_taxnomy' in annotations:
+        annotations = annotations.sort_values('bin_taxonomy')
+
+    # Check the columns are present
+    check_columns(annotations, logger)
+
+    if trna_path is None:
+        trna_frame = None
+    else:
+        trna_frame = pd.read_csv(trna_path, sep='\t')
+    if rrna_path is None:
+        rrna_frame = None
+    else:
+        rrna_frame = pd.read_csv(rrna_path, sep='\t')
+
+    # get db_locs and read in dbs
+    database_handler = DatabaseHandler(logger, config_loc=config_loc)
+    if 'genome_summary_form' not in database_handler.config["dram_sheets"]:
+        raise ValueError('Genome summary form location must be set in order to summarize genomes')
+    # if 'module_step_form' not in database_handler.config["dram_sheets"]:
+    #     raise ValueError('Module step form location must be set in order to summarize genomes')
+    # if 'function_heatmap_form' not in database_handler.config["dram_sheets"]:
+    #     raise ValueError('Functional heat map form location must be set in order to summarize genomes')
+
+    # read in dbs
+    genome_summary_form = pd.read_csv(database_handler.config["dram_sheets"]['genome_summary_form'], sep='\t')
+    if custom_distillate is not None:
+        genome_summary_form = pd.concat([genome_summary_form, pd.read_csv(custom_distillate, sep='\t')])
+    if f"{CAMPER_NAME}_id" in annotations:
+        if 'camper_distillate' not in database_handler.config["dram_sheets"]:
+            raise ValueError(f"Genome summary form location for {CAMPER_NAME} "
+                             "must be set in order to summarize genomes with this database.")
+        genome_summary_form = pd.concat([
+            genome_summary_form,
+            pd.read_csv(database_handler.config["dram_sheets"]['camper_distillate'], sep='\t')])
+    genome_summary_form = genome_summary_form.drop('potential_amg', axis=1)
+    # module_steps_form = pd.read_csv(
+    #     database_handler.config["dram_sheets"]['module_step_form'], sep='\t')
+    # function_heatmap_form = pd.read_csv(
+    #     database_handler.config["dram_sheets"]['function_heatmap_form'], sep='\t')
+    # etc_module_df = pd.read_csv(
+    #     database_handler.config["dram_sheets"]['etc_module_database'], sep='\t')
+    logger.info('Retrieved database locations and descriptions')
+
+    # make genome stats
+    genome_stats = make_genome_stats(annotations, rrna_frame, trna_frame, groupby_column=groupby_column)
+    genome_stats.to_csv(path.join(output_dir, 'genome_stats.tsv'), sep='\t', index=None)
+    logger.info('Calculated genome statistics')
+
+    # make genome metabolism summary
+    genome_summary = path.join(output_dir, 'metabolism_summary.xlsx')
+    if distillate_gene_names:
+        summarized_genomes = fill_genome_summary_frame_gene_names(annotations, genome_summary_form, groupby_column, logger)
+    else:
+        summarized_genomes = make_genome_summary(annotations, genome_summary_form, logger, trna_frame, rrna_frame,
+                                                 groupby_column)
+    write_summarized_genomes_to_xlsx(summarized_genomes, genome_summary)
+    logger.info('Generated genome metabolism summary')
+
+    # # make liquor
+    # if 'bin_taxonomy' in annotations:
+    #     genome_order = get_ordered_uniques(annotations.sort_values('bin_taxonomy')[groupby_column])
+    #     # if gtdb format then get phylum and most specific
+    #     if all([i[:3] == 'd__' and len(i.split(';')) == 7 for i in annotations['bin_taxonomy'].fillna('')]):
+    #         taxa_str_parser = get_phylum_and_most_specific
+    #     # else just throw in what is there
+    #     else:
+    #         taxa_str_parser = lambda x: x
+    #     labels = make_strings_no_repeats({row[groupby_column]: taxa_str_parser(row['bin_taxonomy'])
+    #                                      for _, row in annotations.iterrows()})
+    # else:
+    #     genome_order = get_ordered_uniques(annotations.sort_values(groupby_column)[groupby_column])
+    #     labels = None
+
+    # # make module coverage frame
+    # module_nets = {module: build_module_net(module_df)
+    #                for module, module_df in module_steps_form.groupby('module') if module in HEATMAP_MODULES}
+
+    # if len(genome_order) > genomes_per_product:
+    #     module_coverage_dfs = list()
+    #     etc_coverage_dfs = list()
+    #     function_dfs = list()
+    #     # generates slice start and slice end to grab from genomes and labels from 0 to end of genome order
+    #     pairwise_iter = pairwise(list(range(0, len(genome_order), genomes_per_product)) + [len(genome_order)])
+    #     for i, (start, end) in enumerate(pairwise_iter):
+    #         genomes = genome_order[start:end]
+    #         annotations_subset = annotations.loc[[genome in genomes for genome in annotations[groupby_column]]]
+    #         dfs = fill_liquor_dfs(annotations_subset, module_nets, etc_module_df, function_heatmap_form,
+    #                               logger, groupby_column='fasta')
+    #         module_coverage_df_subset, etc_coverage_df_subset, function_df_subset = dfs
+    #         module_coverage_dfs.append(module_coverage_df_subset)
+    #         etc_coverage_dfs.append(etc_coverage_df_subset)
+    #         function_dfs.append(function_df_subset)
+    #         liquor = make_liquor_heatmap(module_coverage_df_subset, etc_coverage_df_subset, function_df_subset,
+    #                                      genomes, labels)
+    #         liquor.save(path.join(output_dir, 'product_%s.html' % i))
+    #     liquor_df = make_liquor_df(pd.concat(module_coverage_dfs), pd.concat(etc_coverage_dfs), pd.concat(function_dfs))
+    # else:
+    #     module_coverage_df, etc_coverage_df, function_df = fill_liquor_dfs(
+    #         annotations,
+    #         module_nets,
+    #         etc_module_df,
+    #         function_heatmap_form,
+    #         logger,
+    #         groupby_column=groupby_column)
+    #     liquor_df = make_liquor_df(module_coverage_df, etc_coverage_df, function_df)
+    #     liquor = make_liquor_heatmap(module_coverage_df, etc_coverage_df, function_df, genome_order, None)
+    #     liquor.save(path.join(output_dir, 'product.html'))
+    # liquor_df.to_csv(path.join(output_dir, 'product.tsv'), sep='\t')
+    # logger.info('Generated product heatmap and table')
+    # logger.info("Completed distillation")
+    
+if __name__ == "__main__":
+    distill()

--- a/bin/distill.py
+++ b/bin/distill.py
@@ -1,69 +1,48 @@
+#!/usr/bin/env python
 """This is the script that distills the genomes"""
 import logging
 from collections import Counter
 from itertools import chain
 import pandas as pd
 from collections import Counter, defaultdict
-from os import path, mkdir
-import altair as alt
-import networkx as nx
-from itertools import tee
 import re
 import numpy as np
-from datetime import datetime
 import click
+import os
+from pathlib import Path
 
-from mag_annotator.database_handler import DatabaseHandler
-from mag_annotator.utils import get_ordered_uniques, setup_logger
-from mag_annotator.camper_kit import NAME as CAMPER_NAME
+from utils.logger import get_logger
+from utils.click_utils import validate_comma_separated
+from rule_adjectives.annotations import FUNCTION_DICT
 
 # TODO: add RBH information to output
 # TODO: add flag to output table and not xlsx
 # TODO: add flag to output heatmap table
 
-FRAME_COLUMNS = ['gene_id', 'gene_description', 'module', 'sheet', 'header', 'subheader']
+logger = get_logger()
+
+COL_GENE_ID, COL_GENE_DESCRIPTION, COL_MODULE, COL_SHEET, COL_HEADER, COL_SUBHEADER = 'gene_id', 'gene_description', 'pathway', 'topic_ecosystem','category', 'subcategory'
+FRAME_COLUMNS = [COL_GENE_ID, COL_GENE_DESCRIPTION, COL_MODULE, COL_SHEET, COL_HEADER, COL_SUBHEADER]
 RRNA_TYPES = ['5S rRNA', '16S rRNA', '23S rRNA']
-HEATMAP_MODULES = ['M00001', 'M00004', 'M00008', 'M00009', 'M00012', 'M00165', 'M00173',
-                   'M00374', 'M00375', 'M00376', 'M00377', 'M00422', 'M00567']
-HEATMAP_CELL_HEIGHT = 10
-HEATMAP_CELL_WIDTH = 10
-KO_REGEX = r'^K\d\d\d\d\d$'
-ETC_COVERAGE_COLUMNS = ['module_id', 'module_name', 'complex', 'genome', 'path_length',
-                        'path_length_coverage', 'percent_coverage', 'genes', 'missing_genes',
-                        'complex_module_name']
 TAXONOMY_LEVELS = ['d', 'p', 'c', 'o', 'f', 'g', 's']
-COL_HEADER, COL_SUBHEADER, COL_MODULE, COL_GENE_ID, COL_GENE_DESCRIPTION = 'header', 'subheader', 'module', 'gene_id', 'gene_description'
 CONSTANT_DISTILLATE_COLUMNS = [COL_GENE_ID, COL_GENE_DESCRIPTION, COL_MODULE, COL_HEADER, COL_SUBHEADER]
 DISTILATE_SORT_ORDER_COLUMNS = [COL_HEADER, COL_SUBHEADER, COL_MODULE, COL_GENE_ID]
 EXCEL_MAX_CELL_SIZE = 32767
 
-ID_FUNCTION_DICT = {
-    'kegg_genes_id': lambda x: [x],
-    'ko_id': lambda x: [j for j in x.split(',')],
-    'kegg_id': lambda x: [j for j in x.split(',')],
-    'kegg_hit': lambda x: [i[1:-1] for i in
-                           re.findall(r'\[EC:\d*.\d*.\d*.\d*\]', x)],
-    'peptidase_family': lambda x: [j for j in x.split(';')],
-    'cazy_best_hit': lambda x: [x.split('_')[0]],
-    'pfam_hits': lambda x: [j[1:-1].split('.')[0]
-                            for j in re.findall(r'\[PF\d\d\d\d\d.\d*\]', x)],
-    'camper_id': lambda x: [x],
-    'fegenie_id': lambda x: [x],
-    'sulfur_id': lambda x: [x],
-    'methyl_id': lambda x: [i.split(' ')[0].strip() for i in x.split(',')]
-}
+FASTA_COLUMN = os.getenv('FASTA_COLUMN')
+DISTILL_DIR = Path(__file__).parent.parent / "assets/forms/distill_sheets"
 
 
 def check_columns(data, logger):
-    functions = {i:j for i,j in ID_FUNCTION_DICT.items() if i in data.columns}
-    missing = [i for i in ID_FUNCTION_DICT if i not in data.columns]
-    logger.info("Note: the fallowing id fields "
+    functions = {i:j for i,j in FUNCTION_DICT.items() if i in data.columns}
+    missing = [i for i in FUNCTION_DICT if i not in data.columns]
+    logger.info("Note: the following id fields "
           f"were not in the annotations file and are not being used: {missing},"
           f" but these are {list(functions.keys())}")
 
 
 def get_ids_from_annotations_by_row(data):
-    functions = {i:j for i,j in ID_FUNCTION_DICT.items() if i in data.columns}
+    functions = {i:j for i,j in FUNCTION_DICT.items() if i in data.columns}
     out = data.apply(lambda x: {i for k, v in functions.items() if not pd.isna(x[k])
                           for i in v(str(x[k])) if not pd.isna(i)}, axis=1)
     return out
@@ -77,20 +56,23 @@ def get_ids_from_annotations_all(data):
 
 
 def fill_genome_summary_frame(annotations, genome_summary_frame, groupby_column, logger):
-    genome_summary_id_sets = [set([str(k).strip() for k in j.split(',')]) for j in genome_summary_frame['gene_id']]
+    genome_summary_id_sets = [set([str(k).strip() for k in j.split(',')]) for j in genome_summary_frame[COL_GENE_ID]]
+    logger.info(f"Genome summary ID sets: {genome_summary_id_sets}")
     
     def fill_a_frame(frame: pd.DataFrame):
         id_dict = get_ids_from_annotations_all(frame)
+        logger.info(f"ID dictionary for {frame.name}: {id_dict}")
         
         counts = list()
-        for i in genome_summary_id_sets:
+        for set_ in genome_summary_id_sets:
             identifier_count = 0
-            for j in i:
+            for gene_id in set_:
                 # Try matching with and without '.hmm'
-                matching_keys = [key for key in id_dict.keys() if j == key or key.startswith(j + ".")]
+                matching_keys = [key for key in id_dict.keys() if gene_id == key or key.startswith(gene_id + ".")]
                 for key in matching_keys:
                     identifier_count += id_dict[key]
             counts.append(identifier_count)
+        # logger.info(f"Counts for {frame.name}: {counts}")
         
         return pd.Series(counts, index=genome_summary_frame.index)
     
@@ -101,7 +83,7 @@ def fill_genome_summary_frame(annotations, genome_summary_frame, groupby_column,
 
 
 def fill_genome_summary_frame_gene_names(annotations, genome_summary_frame, groupby_column, logger):
-    genome_summary_id_sets = [set([k.strip() for k in j.split(',')]) for j in genome_summary_frame['gene_id']]
+    genome_summary_id_sets = [set([k.strip() for k in j.split(',')]) for j in genome_summary_frame[COL_GENE_ID]]
     for genome, frame in annotations.groupby(groupby_column, sort=False):
         # make dict of identifiers to gene names
         id_gene_dict = defaultdict(list)
@@ -119,7 +101,7 @@ def fill_genome_summary_frame_gene_names(annotations, genome_summary_frame, grou
     return genome_summary_frame
 
 
-def summarize_rrnas(rrnas_df, groupby_column='fasta'):
+def summarize_rrnas(rrnas_df, groupby_column=FASTA_COLUMN):
     genome_rrna_dict = dict()
     for genome, frame in rrnas_df.groupby(groupby_column):
         genome_rrna_dict[genome] = Counter(frame['type'])
@@ -133,9 +115,9 @@ def summarize_rrnas(rrnas_df, groupby_column='fasta'):
     return rrna_frame
 
 
-def summarize_trnas(trnas_df, groupby_column='fasta'):
+def summarize_trnas(trnas_df, groupby_column=FASTA_COLUMN):
     # first build the frame
-    combos = {(line.Type, line.Codon, line.Note) for _, line in trnas_df.iterrows()}
+    combos = {(line.type, line.codon, line.note) for _, line in trnas_df.iterrows()}
     frame_rows = list()
     for combo in combos:
         if combo[2] == 'pseudo':
@@ -149,24 +131,24 @@ def summarize_trnas(trnas_df, groupby_column='fasta'):
         module_description = '%s tRNA' % combo[0]
         frame_rows.append([gene_id, gene_description, module_description, 'tRNA', 'tRNA', ''])
     trna_frame = pd.DataFrame(frame_rows, columns=FRAME_COLUMNS)
-    trna_frame = trna_frame.sort_values('gene_id')
+    trna_frame = trna_frame.sort_values(COL_GENE_ID)
     # then fill it in
-    trna_frame = trna_frame.set_index('gene_id')
+    trna_frame = trna_frame.set_index(COL_GENE_ID)
     for group, frame in trnas_df.groupby(groupby_column):
         gene_ids = list()
         for index, line in frame.iterrows():
-            if line.Note == 'pseudo':
+            if line.note == 'pseudo':
                 gene_id = '%s, pseudo (%s)'
             else:
                 gene_id = '%s (%s)'
-            gene_ids.append(gene_id % (line.Type, line.Codon))
+            gene_ids.append(gene_id % (line.type, line.codon))
         trna_frame[group] = pd.Series(Counter(gene_ids))
     trna_frame = trna_frame.reset_index()
     trna_frame = trna_frame.fillna(0)
     return trna_frame
 
 
-def make_genome_summary(annotations, genome_summary_frame, logger, trna_frame=None, rrna_frame=None, groupby_column='fasta'):
+def make_genome_summary(annotations, genome_summary_frame, logger, trna_frame=None, rrna_frame=None, groupby_column=FASTA_COLUMN):
     summary_frames = list()
     # get ko summaries
     summary_frames.append(fill_genome_summary_frame(annotations, genome_summary_frame.copy(), groupby_column, logger))
@@ -210,446 +192,36 @@ def split_names_to_long(col:pd.Series):
 def write_summarized_genomes_to_xlsx(summarized_genomes, output_file):
     # turn all this into an xlsx
     with pd.ExcelWriter(output_file) as writer:
-        for sheet, frame in summarized_genomes.groupby('sheet', sort=False):
+        for sheet, frame in summarized_genomes.groupby(COL_SHEET, sort=False):
             frame = frame.sort_values(DISTILATE_SORT_ORDER_COLUMNS)
-            frame = frame.drop(['sheet'], axis=1)
+            frame = frame.drop([COL_SHEET], axis=1)
             gene_columns = list(set(frame.columns) - set(CONSTANT_DISTILLATE_COLUMNS))
             split_genes = pd.concat([split_names_to_long(frame[i].astype(str)) for i in gene_columns], axis=1)
             frame = pd.concat([frame[CONSTANT_DISTILLATE_COLUMNS],  split_genes], axis=1)
             frame.to_excel(writer, sheet_name=sheet, index=False)
 
 
-# TODO: add assembly stats like N50, longest contig, total assembled length etc
-def make_genome_stats(annotations, rrna_frame=None, trna_frame=None, groupby_column='fasta'):
-    rows = list()
-    columns = ['genome']
-    if 'scaffold' in annotations.columns:
-        columns.append('number of scaffolds')
-    if 'bin_taxonomy' in annotations.columns:
-        columns.append('taxonomy')
-    if 'bin_completeness' in annotations.columns:
-        columns.append('completeness score')
-    if 'bin_contamination' in annotations.columns:
-        columns.append('contamination score')
-    if rrna_frame is not None:
-        columns += RRNA_TYPES
-    if trna_frame is not None:
-        columns.append('tRNA count')
-    if 'bin_completeness' in annotations.columns and 'bin_contamination' in annotations.columns \
-       and rrna_frame is not None and trna_frame is not None:
-        columns.append('assembly quality')
-    for genome, frame in annotations.groupby(groupby_column, sort=False):
-        row = [genome]
-        if 'scaffold' in frame.columns:
-            row.append(len(set(frame['scaffold'])))
-        if 'bin_taxonomy' in frame.columns:
-            row.append(frame['bin_taxonomy'][0])
-        if 'bin_completeness' in frame.columns:
-            row.append(frame['bin_completeness'][0])
-        if 'bin_contamination' in frame.columns:
-            row.append(frame['bin_contamination'][0])
-        has_rrna = list()
-        if rrna_frame is not None:
-            genome_rrnas = rrna_frame.loc[rrna_frame.fasta == genome]
-            for rrna in RRNA_TYPES:
-                sixteens = genome_rrnas.loc[genome_rrnas.type == rrna]
-                if sixteens.shape[0] == 0:
-                    row.append('')
-                    has_rrna.append(False)
-                elif sixteens.shape[0] == 1:
-                    row.append('%s (%s, %s)' % (sixteens['scaffold'].iloc[0], sixteens.begin.iloc[0],
-                                                sixteens.end.iloc[0]))
-                    has_rrna.append(True)
-                else:
-                    row.append('%s present' % sixteens.shape[0])
-                    has_rrna.append(False)
-        if trna_frame is not None:
-            # TODO: remove psuedo from count?
-            row.append(trna_frame.loc[trna_frame[groupby_column] == genome].shape[0])
-        if 'assembly quality' in columns:
-            if frame['bin_completeness'][0] > 90 and frame['bin_contamination'][0] < 5 and np.all(has_rrna) and \
-               len(set(trna_frame.loc[trna_frame[groupby_column] == genome].Type)) >= 18:
-                row.append('high')
-            elif frame['bin_completeness'][0] >= 50 and frame['bin_contamination'][0] < 10:
-                row.append('med')
-            else:
-                row.append('low')
-        rows.append(row)
-    genome_stats = pd.DataFrame(rows, columns=columns)
-    return genome_stats
-
-
-def build_module_net(module_df):
-    """Starts with a data from including a single module"""
-    # build net from a set of module paths
-    num_steps = max([int(i.split(',')[0]) for i in set(module_df['path'])])
-    module_net = nx.DiGraph(num_steps=num_steps, module_id=list(module_df['module'])[0],
-                            module_name=list(module_df['module_name'])[0])
-    # go through all path/step combinations
-    for module_path, frame in module_df.groupby('path'):
-        split_path = [int(i) for i in module_path.split(',')]
-        step = split_path[0]
-        module_net.add_node(module_path, kos=set(frame['ko']))
-        # add incoming edge
-        if step != 0:
-            module_net.add_edge('end_step_%s' % (step - 1), module_path)
-        # add outgoing edge
-        module_net.add_edge(module_path, 'end_step_%s' % step)
-    return module_net
-
-
-def get_module_step_coverage(kos, module_net):
-    # prune network based on what kos were observed
-    pruned_module_net = module_net.copy()
-    module_kos_present = set()
-    for node, data in module_net.nodes.items():
-        if 'kos' in data:
-            ko_overlap = data['kos'] & kos
-            if len(ko_overlap) == 0:
-                pruned_module_net.remove_node(node)
-            else:
-                module_kos_present = module_kos_present | ko_overlap
-    # count number of missing steps
-    missing_steps = 0
-    for node, data in pruned_module_net.nodes.items():
-        if ('end_step' in node) and (pruned_module_net.in_degree(node) == 0):
-            missing_steps += 1
-    # get statistics
-    num_steps = pruned_module_net.graph['num_steps'] + 1
-    num_steps_present = num_steps - missing_steps
-    coverage = num_steps_present / num_steps
-    return num_steps, num_steps_present, coverage, sorted(module_kos_present)
-
-
-def make_module_coverage_df(annotation_df, module_nets):
-    kos_to_genes = defaultdict(list)
-    ko_id_name = 'kegg_id' if 'kegg_id' in annotation_df.columns else 'ko_id'
-    for gene_id, ko_list in annotation_df[ko_id_name].items():
-        if type(ko_list) is str:
-            for ko in ko_list.split(','):
-                kos_to_genes[ko].append(gene_id)
-    coverage_dict = {}
-    for i, (module, net) in enumerate(module_nets.items()):
-        module_steps, module_steps_present, module_coverage, module_kos = \
-            get_module_step_coverage(set(kos_to_genes.keys()), net)
-        module_genes = sorted([gene for ko in module_kos for gene in kos_to_genes[ko]])
-        coverage_dict[module] = [net.graph['module_name'], module_steps, module_steps_present, module_coverage,
-                                 len(module_kos), ','.join(module_kos), ','.join(module_genes)]
-    coverage_df = pd.DataFrame.from_dict(coverage_dict, orient='index',
-                                         columns=['module_name', 'steps', 'steps_present', 'step_coverage', 'ko_count',
-                                                  'kos_present', 'genes_present'])
-    return coverage_df
-
-
-def make_module_coverage_frame(annotations, module_nets, groupby_column='fasta'):
-    # go through each scaffold to check for modules
-    module_coverage_dict = dict()
-    for group, frame in annotations.groupby(groupby_column, sort=False):
-        module_coverage_dict[group] = make_module_coverage_df(frame, module_nets)
-    module_coverage = pd.concat(module_coverage_dict)
-    module_coverage.index = module_coverage.index.set_names(['genome', 'module'])
-    return module_coverage.reset_index()
-
-
-def make_module_coverage_heatmap(module_coverage, mag_order=None):
-    num_mags_in_frame = len(set(module_coverage['genome']))
-    c = alt.Chart(module_coverage, title='Module').encode(
-        x=alt.X('module_name', title=None, sort=None, axis=alt.Axis(labelLimit=0, labelAngle=90)),
-        y=alt.Y('genome', title=None, sort=mag_order, axis=alt.Axis(labelLimit=0)),
-        tooltip=[alt.Tooltip('genome', title='Genome'),
-                 alt.Tooltip('module_name', title='Module Name'),
-                 alt.Tooltip('steps', title='Module steps'),
-                 alt.Tooltip('steps_present', title='Steps present')
-                 ]
-    ).mark_rect().encode(color=alt.Color('step_coverage', legend=alt.Legend(title='% Complete'),
-                                         scale=alt.Scale(domain=(0, 1)))).properties(
-        width=HEATMAP_CELL_WIDTH * len(HEATMAP_MODULES),
-        height=HEATMAP_CELL_HEIGHT * num_mags_in_frame)
-    return c
-
-
-def pairwise(iterable):
-    """s -> (s0,s1), (s1,s2), (s2, s3), ..."""
-    a, b = tee(iterable)
-    next(b, None)
-    return zip(a, b)
-
-
-def first_open_paren_is_all(str_):
-    """Go through string and return true"""
-    curr_level = 1
-    for char in str_[1:-1]:
-        if char == ')':
-            curr_level -= 1
-        elif char == '(':
-            curr_level += 1
-        if curr_level == 0:
-            return False
-    return True
-
-
-def split_into_steps(definition, split_char=' '):
-    """Very fancy split on string of chars"""
-    curr_level = 0
-    step_starts = [-1]
-    for i, char in enumerate(definition):
-        if char == '(':
-            curr_level += 1
-        if char == ')':
-            curr_level -= 1
-        if (curr_level == 0) and (char in split_char):
-            step_starts.append(i)
-    step_starts.append(len(definition))
-    steps = list()
-    for a, b in pairwise(step_starts):
-        step = definition[a+1:b]
-        if step.startswith('(') and step.endswith(')'):
-            if first_open_paren_is_all(step):
-                step = step[1:-1]
-        steps.append(step)
-    return steps
-
-
-def is_ko(ko):
-    return re.match(KO_REGEX, ko) is not None
-
-
-def make_module_network(definition, network: nx.DiGraph = None, parent_nodes=('start',)):
-    # TODO: Figure out how to add 'end' step to last step at end
-    if network is None:
-        network = nx.DiGraph()
-    last_steps = []
-    for step in split_into_steps(definition, ','):
-        prev_steps = parent_nodes
-        for substep in split_into_steps(step, '+'):
-            if is_ko(substep):
-                for prev_step in prev_steps:
-                    network.add_edge(prev_step, substep)
-                prev_steps = [substep]
-            else:
-                network, prev_steps = make_module_network(substep, network, prev_steps)
-        last_steps += prev_steps
-    return network, last_steps
-
-
-def get_module_coverage(module_net: nx.DiGraph, genes_present: set):
-    max_coverage = -1
-    max_coverage_genes = list()
-    max_coverage_missing_genes = list()
-    max_path_len = 0
-    for net_path in nx.all_simple_paths(module_net, source='start', target='end'):
-        net_path = set(net_path[1:-1])
-        overlap = net_path & genes_present
-        coverage = len(overlap) / len(net_path)
-        if coverage > max_coverage:
-            max_coverage = coverage
-            max_coverage_genes = overlap
-            max_coverage_missing_genes = net_path - genes_present
-            max_path_len = len(net_path)
-    return max_path_len, len(max_coverage_genes), max_coverage, max_coverage_genes, max_coverage_missing_genes
-
-
-def make_etc_coverage_df(etc_module_df, annotations, groupby_column='fasta'):
-    etc_coverage_df_rows = list()
-    for _, module_row in etc_module_df.iterrows():
-        definition = module_row['definition']
-        # remove optional subunits
-        definition = re.sub(r'-K\d\d\d\d\d', '', definition)
-        module_net, _ = make_module_network(definition)
-        # add end node
-        no_out = [node for node in module_net.nodes() if module_net.out_degree(node) == 0]
-        for node in no_out:
-            module_net.add_edge(node, 'end')
-        # go through each genome and check pathway coverage
-        for group, frame in annotations.groupby(groupby_column):
-            # get annotation genes
-            grouped_ids = set(get_ids_from_annotations_all(frame).keys())
-            path_len, path_coverage_count, path_coverage_percent, genes, missing_genes = \
-                get_module_coverage(module_net, grouped_ids)
-            complex_module_name = 'Complex %s: %s' % (module_row['complex'].replace('Complex ', ''),
-                                                      module_row['module_name'])
-            etc_coverage_df_rows.append([module_row['module_id'], module_row['module_name'],
-                                         module_row['complex'].replace('Complex ', ''), group, path_len,
-                                         path_coverage_count, path_coverage_percent, ','.join(sorted(genes)),
-                                         ','.join(sorted(missing_genes)), complex_module_name])
-    return pd.DataFrame(etc_coverage_df_rows, columns=ETC_COVERAGE_COLUMNS)
-
-
-def make_etc_coverage_heatmap(etc_coverage, mag_order=None, module_order=None):
-    num_mags_in_frame = len(set(etc_coverage['genome']))
-    charts = list()
-    for i, (etc_complex, frame) in enumerate(etc_coverage.groupby('complex')):
-        # if this is the first chart then make y-ticks otherwise none
-        c = alt.Chart(frame, title=etc_complex).encode(
-            x=alt.X('module_name', title=None, axis=alt.Axis(labelLimit=0, labelAngle=90),
-                    sort=module_order),
-            y=alt.Y('genome', axis=alt.Axis(title=None, labels=False, ticks=False), sort=mag_order),
-            tooltip=[alt.Tooltip('genome', title='Genome'),
-                     alt.Tooltip('module_name', title='Module Name'),
-                     alt.Tooltip('path_length', title='Module Subunits'),
-                     alt.Tooltip('path_length_coverage', title='Subunits present'),
-                     alt.Tooltip('genes', title='Genes present'),
-                     alt.Tooltip('missing_genes', title='Genes missing')
-                     ]
-        ).mark_rect().encode(color=alt.Color('percent_coverage', legend=alt.Legend(title='% Complete'),
-                                             scale=alt.Scale(domain=(0, 1)))).properties(
-            width=HEATMAP_CELL_WIDTH * len(set(frame['module_name'])),
-            height=HEATMAP_CELL_HEIGHT * num_mags_in_frame)
-        charts.append(c)
-    concat_title = alt.TitleParams('ETC Complexes', anchor='middle')
-    return alt.hconcat(*charts, spacing=5, title=concat_title)
-
-
-def make_functional_df(annotations, function_heatmap_form, logger, groupby_column='fasta'):
-    # clean up function heatmap form
-    function_heatmap_form = function_heatmap_form.apply(lambda x: x.str.strip() if x.dtype == "object" else x)
-    function_heatmap_form = function_heatmap_form.fillna('')
-    # build dict of ids per genome
-    genome_to_id_dict = dict()
-    for genome, frame in annotations.groupby(groupby_column, sort=False):
-        id_list = get_ids_from_annotations_all(frame).keys()
-        genome_to_id_dict[genome] = set(id_list)
-    # build long from data frame
-    rows = list()
-    for function, frame in function_heatmap_form.groupby('function_name', sort=False):
-        for bin_name, id_set in genome_to_id_dict.items():
-            presents_in_bin = list()
-            functions_present = set()
-            for _, row in frame.iterrows():
-                function_id_set = set([i.strip() for i in row.function_ids.strip().split(',')])
-                present_in_bin = id_set & function_id_set
-                functions_present = functions_present | present_in_bin
-                presents_in_bin.append(len(present_in_bin) > 0)
-            function_in_bin = np.all(presents_in_bin)
-            row = frame.iloc[0]
-            rows.append([row.category, row.subcategory, row.function_name, ', '.join(functions_present),
-                         '; '.join(get_ordered_uniques(frame.long_function_name)),
-                         '; '.join(get_ordered_uniques(frame.gene_symbol)), bin_name, function_in_bin,
-                         '%s: %s' % (row.category, row.function_name)])
-    return pd.DataFrame(rows, columns=list(function_heatmap_form.columns) + ['genome', 'present',
-                                                                             'category_function_name'])
-
-
-def make_functional_heatmap(functional_df, mag_order=None):
-    # build heatmaps
-    charts = list()
-    for i, (group, frame) in enumerate(functional_df.groupby('category', sort=False)):
-        # set variables for chart
-        function_order = get_ordered_uniques(list(frame.function_name))
-        num_mags_in_frame = len(set(frame['genome']))
-        chart_width = HEATMAP_CELL_WIDTH * len(function_order)
-        chart_height = HEATMAP_CELL_HEIGHT * num_mags_in_frame
-        # if this is the first chart then make y-ticks otherwise none
-        if i == 0:
-            y = alt.Y('genome', title=None, sort=mag_order,
-                      axis=alt.Axis(labelLimit=0, labelExpr="replace(datum.label, /_\d*$/gi, '')"))
-        else:
-            y = alt.Y('genome', axis=alt.Axis(title=None, labels=False, ticks=False), sort=mag_order)
-        # set up colors for chart
-        rect_colors = alt.Color('present',
-                                legend=alt.Legend(title="Function is Present", symbolType='square',
-                                                  values=[True, False]),
-                                sort=[True, False],
-                                scale=alt.Scale(range=['#2ca25f', '#e5f5f9']))
-        # define chart
-        # TODO: Figure out how to angle title to take up less space
-        c = alt.Chart(frame, title=alt.TitleParams(group)).encode( x=alt.X('function_name', title=None, axis=alt.Axis(labelLimit=0, labelAngle=90), sort=function_order), tooltip=[alt.Tooltip('genome', title='Genome'), alt.Tooltip('category', title='Category'), alt.Tooltip('subcategory', title='Subcategory'), alt.Tooltip('function_ids', title='Function IDs'), alt.Tooltip('function_name', title='Function'), alt.Tooltip('long_function_name', title='Description'), alt.Tooltip('gene_symbol', title='Gene Symbol')]).mark_rect().encode(y=y, color=rect_colors).properties( width=chart_width, height=chart_height)
-        charts.append(c)
-    # merge and return
-    function_heatmap = alt.hconcat(*charts, spacing=5)
-    return function_heatmap
-
-
-# TODO: refactor this to handle splitting large numbers of genomes into multiple heatmaps here
-def fill_liquor_dfs(annotations, module_nets, etc_module_df, function_heatmap_form, logger, groupby_column='fasta'):
-    module_coverage_frame = make_module_coverage_frame(annotations, module_nets, groupby_column)
-
-    # make ETC frame
-    etc_coverage_df = make_etc_coverage_df(etc_module_df, annotations, groupby_column)
-
-    # make functional frame
-    function_df = make_functional_df(annotations, function_heatmap_form, logger, groupby_column)
-
-    return module_coverage_frame, etc_coverage_df, function_df
-
-
-def rename_genomes_to_taxa(function_df, labels, mag_order):
-    function_df = function_df.copy()
-    new_genome_column = [labels[i] for i in function_df['genome']]
-    function_df['genome'] = pd.Series(new_genome_column, index=function_df.index)
-    mag_order = [labels[i] for i in mag_order]
-    return function_df, mag_order
-
-
-def make_liquor_heatmap(module_coverage_frame, etc_coverage_df, function_df, mag_order=None, labels=None):
-    module_coverage_heatmap = make_module_coverage_heatmap(module_coverage_frame, mag_order)
-    etc_heatmap = make_etc_coverage_heatmap(etc_coverage_df, mag_order=mag_order)
-    if labels is not None:
-        function_df, mag_order = rename_genomes_to_taxa(function_df, labels, mag_order)
-    function_heatmap = make_functional_heatmap(function_df, mag_order)
-
-    liquor = alt.hconcat(alt.hconcat(module_coverage_heatmap, etc_heatmap), function_heatmap)
-    return liquor
-
-
-def make_liquor_df(module_coverage_frame, etc_coverage_df, function_df):
-    liquor_df = pd.concat([module_coverage_frame.pivot(index='genome', columns='module_name', values='step_coverage'),
-                           etc_coverage_df.pivot(index='genome', columns='complex_module_name',
-                                                 values='percent_coverage'),
-                           function_df.pivot(index='genome', columns='category_function_name', values='present')],
-                          axis=1, sort=False)
-    return liquor_df
-
-
-def get_phylum_and_most_specific(taxa_str):
-    taxa_ranks = [i[3:] for i in taxa_str.split(';')]
-    phylum = taxa_ranks[1]
-    most_specific_rank = TAXONOMY_LEVELS[sum([len(i) > 0 for i in taxa_ranks])-1]
-    most_specific_taxa = taxa_ranks[sum([len(i) > 0 for i in taxa_ranks]) - 1]
-    if most_specific_rank == 'd':
-        return 'd__%s;p__' % most_specific_taxa
-    if most_specific_rank == 'p':
-        return 'p__%s;c__' % most_specific_taxa
-    else:
-        return 'p__%s;%s__%s' % (phylum, most_specific_rank, most_specific_taxa)
-
-
-def make_strings_no_repeats(genome_taxa_dict):
-    labels = dict()
-    seen = Counter()
-    for genome, taxa_string in genome_taxa_dict.items():
-        final_taxa_string = '%s_%s' % (taxa_string, str(seen[taxa_string]))
-        seen[taxa_string] += 1
-        labels[genome] = final_taxa_string
-    return labels
-
-
 @click.command()
 @click.option("-i", "--input_file", required=True, help="Annotations path")
-@click.option("-o", "--output_dir", required=True, help="Directory to write summarized genomes")
+# @click.option("-o", "--output_dir", required=True, help="Directory to write summarized genomes")
 @click.option('--log_file_path', 
                                     help="A name and loctation for the log file")
 @click.option("--rrna_path", help="rRNA output from annotation")
 @click.option("--trna_path", help="tRNA output from annotation")
 @click.option("--groupby_column", help="Column from annotations to group as organism units",
-                            default='fasta')
-@click.option('--config_loc', default=None,
-                            help='location of an alternive config file that will over write the original at run time,'
-                            ' but not be saved or modified')
-@click.option("--custom_distillate", help="Custom distillate form to add your own modules")
-@click.option("--distillate_gene_names", action='store_true', default=False,
+                            default=FASTA_COLUMN)
+@click.option("--distil_topics", default="default", help="Default distillates topics to run.")
+@click.option("--distil_ecosystem", default="eng_sys,ag", help="Default distillates ecosystems to run.")
+@click.option("--custom_distillate", default=[], callback=validate_comma_separated, help="Custom distillate forms to add your own modules, comma separated. ")
+@click.option("--distillate_gene_names", is_flag=True,
+    show_default=True, default=False,
                             help="Give names of genes instead of counts in genome metabolism summary")
-def distill(input_file, trna_path=None, rrna_path=None, output_dir='.',
-                      groupby_column='fasta', log_file_path=None, custom_distillate=None,
-                      distillate_gene_names=False, genomes_per_product=1000, config_loc=None):
+def distill(input_file, trna_path=None, rrna_path=None, distil_topics=None, distil_ecosystem=None,
+                      groupby_column=FASTA_COLUMN, log_file_path=None, custom_distillate=None,
+                      distillate_gene_names=False):
     """Summarize metabolic content of annotated genomes"""
     # make output folder
-    mkdir(output_dir)
-    if log_file_path is None:
-        log_file_path = path.join(output_dir, "distill.log")
-    logger = logging.getLogger('distillation_log')
-    setup_logger(logger, log_file_path)
-    logger.info(f"The log file is created at {log_file_path}")
+    # mkdir(output_dir)
 
     # read in data
     annotations = pd.read_csv(input_file, sep='\t', index_col=0)
@@ -668,102 +240,67 @@ def distill(input_file, trna_path=None, rrna_path=None, output_dir='.',
     else:
         rrna_frame = pd.read_csv(rrna_path, sep='\t')
 
-    # get db_locs and read in dbs
-    database_handler = DatabaseHandler(logger, config_loc=config_loc)
-    if 'genome_summary_form' not in database_handler.config["dram_sheets"]:
-        raise ValueError('Genome summary form location must be set in order to summarize genomes')
-    # if 'module_step_form' not in database_handler.config["dram_sheets"]:
-    #     raise ValueError('Module step form location must be set in order to summarize genomes')
-    # if 'function_heatmap_form' not in database_handler.config["dram_sheets"]:
-    #     raise ValueError('Functional heat map form location must be set in order to summarize genomes')
 
-    # read in dbs
-    genome_summary_form = pd.read_csv(database_handler.config["dram_sheets"]['genome_summary_form'], sep='\t')
-    if custom_distillate is not None:
-        genome_summary_form = pd.concat([genome_summary_form, pd.read_csv(custom_distillate, sep='\t')])
-    if f"{CAMPER_NAME}_id" in annotations:
-        if 'camper_distillate' not in database_handler.config["dram_sheets"]:
-            raise ValueError(f"Genome summary form location for {CAMPER_NAME} "
-                             "must be set in order to summarize genomes with this database.")
-        genome_summary_form = pd.concat([
-            genome_summary_form,
-            pd.read_csv(database_handler.config["dram_sheets"]['camper_distillate'], sep='\t')])
-    genome_summary_form = genome_summary_form.drop('potential_amg', axis=1)
-    # module_steps_form = pd.read_csv(
-    #     database_handler.config["dram_sheets"]['module_step_form'], sep='\t')
-    # function_heatmap_form = pd.read_csv(
-    #     database_handler.config["dram_sheets"]['function_heatmap_form'], sep='\t')
-    # etc_module_df = pd.read_csv(
-    #     database_handler.config["dram_sheets"]['etc_module_database'], sep='\t')
-    logger.info('Retrieved database locations and descriptions')
+    distil_dir = Path(__file__).parent.parent / "assets/forms/distill_sheets"
+    distil_sheets_names = []
+    if "default" in distil_topics:
+        distil_sheets_names = [
+            DISTILL_DIR / "distill_carbon.tsv",
+            DISTILL_DIR / "distill_energy.tsv",
+            DISTILL_DIR / "distill_misc.tsv",
+            DISTILL_DIR / "distill_nitrogen.tsv",
+            DISTILL_DIR / "distill_transport.tsv"
+        ]
+    else:
+        if 'carbon' in distil_topics:
+            distil_sheets_names.append(DISTILL_DIR / "distill_carbon.tsv")
+        if 'energy' in distil_topics:
+            distil_sheets_names.append(DISTILL_DIR / "distill_energy.tsv")
+        if 'misc' in distil_topics:
+            distil_sheets_names.append(DISTILL_DIR / "distill_misc.tsv")
+        if 'nitrogen' in distil_topics:
+            distil_sheets_names.append(DISTILL_DIR / "distill_nitrogen.tsv")
+        if 'transport' in distil_topics:
+            distil_sheets_names.append(DISTILL_DIR / "distill_transport.tsv")
+    
+        
+    if "ag" in distil_ecosystem:
+        distil_sheets_names.append(DISTILL_DIR / "distill_ag.tsv")
+    if "eng_sys" in distil_ecosystem:
+        distil_sheets_names.append(DISTILL_DIR / "distill_eng_sys.tsv")
+    
+    if "camper_id" in annotations and ("default" in distil_topics or "camper" in distil_topics):
+        distil_sheets_names.append(DISTILL_DIR / "distill_camper.tsv")
+        
+        
+    if custom_distillate:
+        for custom_sheet in custom_distillate:
+            distil_sheets_names.append(custom_sheet)
+    
+    genome_summary_form = pd.concat(
+        [pd.read_csv(sheet, 
+                     sep='\t', 
+                     usecols=FRAME_COLUMNS) 
+         for sheet in distil_sheets_names],
+    )
+    
+    logger.info('Retrieved distillate genome summary form')
 
-    # make genome stats
-    genome_stats = make_genome_stats(annotations, rrna_frame, trna_frame, groupby_column=groupby_column)
-    genome_stats.to_csv(path.join(output_dir, 'genome_stats.tsv'), sep='\t', index=None)
-    logger.info('Calculated genome statistics')
+    genome_summary_form = genome_summary_form.reset_index(drop=True)
 
     # make genome metabolism summary
-    genome_summary = path.join(output_dir, 'metabolism_summary.xlsx')
+    genome_summary = 'distillate.xlsx'
     if distillate_gene_names:
+        logger.info(f'distillate_gene_names flag is {distillate_gene_names}. Giving gene names instead of counts in genome metabolism summary')
         summarized_genomes = fill_genome_summary_frame_gene_names(annotations, genome_summary_form, groupby_column, logger)
     else:
+        logger.info(f'distillate_gene_names flag is {distillate_gene_names}. Giving counts instead of gene names in genome metabolism summary')
         summarized_genomes = make_genome_summary(annotations, genome_summary_form, logger, trna_frame, rrna_frame,
                                                  groupby_column)
+    summarized_genomes.to_csv('summarized_genomes.tsv', sep='\t', index=None)
     write_summarized_genomes_to_xlsx(summarized_genomes, genome_summary)
     logger.info('Generated genome metabolism summary')
 
-    # # make liquor
-    # if 'bin_taxonomy' in annotations:
-    #     genome_order = get_ordered_uniques(annotations.sort_values('bin_taxonomy')[groupby_column])
-    #     # if gtdb format then get phylum and most specific
-    #     if all([i[:3] == 'd__' and len(i.split(';')) == 7 for i in annotations['bin_taxonomy'].fillna('')]):
-    #         taxa_str_parser = get_phylum_and_most_specific
-    #     # else just throw in what is there
-    #     else:
-    #         taxa_str_parser = lambda x: x
-    #     labels = make_strings_no_repeats({row[groupby_column]: taxa_str_parser(row['bin_taxonomy'])
-    #                                      for _, row in annotations.iterrows()})
-    # else:
-    #     genome_order = get_ordered_uniques(annotations.sort_values(groupby_column)[groupby_column])
-    #     labels = None
-
-    # # make module coverage frame
-    # module_nets = {module: build_module_net(module_df)
-    #                for module, module_df in module_steps_form.groupby('module') if module in HEATMAP_MODULES}
-
-    # if len(genome_order) > genomes_per_product:
-    #     module_coverage_dfs = list()
-    #     etc_coverage_dfs = list()
-    #     function_dfs = list()
-    #     # generates slice start and slice end to grab from genomes and labels from 0 to end of genome order
-    #     pairwise_iter = pairwise(list(range(0, len(genome_order), genomes_per_product)) + [len(genome_order)])
-    #     for i, (start, end) in enumerate(pairwise_iter):
-    #         genomes = genome_order[start:end]
-    #         annotations_subset = annotations.loc[[genome in genomes for genome in annotations[groupby_column]]]
-    #         dfs = fill_liquor_dfs(annotations_subset, module_nets, etc_module_df, function_heatmap_form,
-    #                               logger, groupby_column='fasta')
-    #         module_coverage_df_subset, etc_coverage_df_subset, function_df_subset = dfs
-    #         module_coverage_dfs.append(module_coverage_df_subset)
-    #         etc_coverage_dfs.append(etc_coverage_df_subset)
-    #         function_dfs.append(function_df_subset)
-    #         liquor = make_liquor_heatmap(module_coverage_df_subset, etc_coverage_df_subset, function_df_subset,
-    #                                      genomes, labels)
-    #         liquor.save(path.join(output_dir, 'product_%s.html' % i))
-    #     liquor_df = make_liquor_df(pd.concat(module_coverage_dfs), pd.concat(etc_coverage_dfs), pd.concat(function_dfs))
-    # else:
-    #     module_coverage_df, etc_coverage_df, function_df = fill_liquor_dfs(
-    #         annotations,
-    #         module_nets,
-    #         etc_module_df,
-    #         function_heatmap_form,
-    #         logger,
-    #         groupby_column=groupby_column)
-    #     liquor_df = make_liquor_df(module_coverage_df, etc_coverage_df, function_df)
-    #     liquor = make_liquor_heatmap(module_coverage_df, etc_coverage_df, function_df, genome_order, None)
-    #     liquor.save(path.join(output_dir, 'product.html'))
-    # liquor_df.to_csv(path.join(output_dir, 'product.tsv'), sep='\t')
-    # logger.info('Generated product heatmap and table')
-    # logger.info("Completed distillation")
     
 if __name__ == "__main__":
     distill()

--- a/bin/rule_adjectives/annotations.py
+++ b/bin/rule_adjectives/annotations.py
@@ -16,12 +16,18 @@ SULFUR_ID = 'sulfur_id'
 FEGENIE_ID = 'fegenie_id'
 FUNCTION_DICT = {
     'camper_id': lambda x: [x],
+    'camper_EC': lambda x: [i[1:-1] for i in
+                           re.findall(r'\[EC:\d*.\d*.\d*.\d*\]', x)],
     FEGENIE_ID: lambda x: [x],
     SULFUR_ID: lambda x: [x],
     'kegg_genes_id': lambda x: [x],
     'ko_id': lambda x: [j for j in x.split(',')],
-    'kegg_id': lambda x: [j for j in x.split(',')],
-    'kegg_hit': lambda x: [i[1:-1] for i in
+    'kegg_id': lambda x: [j for j in x.split('/')],
+    'kegg_EC': lambda x: [i[1:-1] for i in
+                           re.findall(r'\[EC:\d*.\d*.\d*.\d*\]', x)],
+    'kofam_genes_id': lambda x: [x],
+    'kofam_id': lambda x: [j for j in x.split('/')],
+    'kofam_EC': lambda x: [i[1:-1] for i in
                            re.findall(r'\[EC:\d*.\d*.\d*.\d*\]', x)],
     'cazy_hits': lambda x: [f"{i[1:3]}:{i[4:-1]}" for i in  # Old formats for Cazy
                             re.findall(r'\(EC [\d+\.]+[\d-]\)', x)],

--- a/bin/sql_add_descriptions.py
+++ b/bin/sql_add_descriptions.py
@@ -64,6 +64,7 @@ def extract_kegg_orthology(description):
     if "(K" in description:
         ko_start = description.find("(K") + 1
         ko_end = description.find(")", ko_start)
+        # return description[ko_start:ko_end].replace("/", "; ")
         return description[ko_start:ko_end]
     else:
         return None

--- a/bin/sql_add_descriptions.py
+++ b/bin/sql_add_descriptions.py
@@ -78,6 +78,7 @@ def format_dbcan_EC(ec_string):
         return ""
 
 def extract_kegg_EC(description):
+    # TODO this could be optimized into one regex with groups I am pretty sure
     # Extract and format EC numbers from the description with "EC:" prefix and semicolon separation
     ec_start = description.find("[EC:")
     if ec_start != -1:

--- a/bin/utils/click_utils.py
+++ b/bin/utils/click_utils.py
@@ -1,0 +1,5 @@
+def validate_comma_separated(ctx, param, value):
+    print(value)
+    if not value:
+        return []
+    return value.split(',')

--- a/bin/utils/logger.py
+++ b/bin/utils/logger.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+import logging
+import os
+
+
+DEFAULT_LOG_LEVEL: int = logging.INFO
+ROOT_LOGGER_NAME = "dram"
+
+
+def get_logger(name: str = ROOT_LOGGER_NAME, level: int = DEFAULT_LOG_LEVEL, filename="dram.log") -> logging.Logger:
+    """Get a logger.
+
+    To set a human-readable "output_name" that appears in logger outputs,
+    add `{"output_name": "[MY_OUTPUT_NAME]"}` to the logger's contextual
+    information. By default, we use the logger's `name`
+
+    NOTE: To change the log level on particular outputs (e.g. STDERR logs),
+    set the proper log level on the relevant handler, instead of the logger
+    e.g. logger.handers[0].setLevel(INFO)
+
+    Args:
+        name: The name of the logger.
+
+    Returns:
+        The logging.Logger object.
+    """
+    logger = logging.getLogger(name)
+    logger = set_handlers(logger=logger, level=level, filename=filename)
+    logger.setLevel(level)
+
+    return logger
+
+
+def set_handlers(logger, level=DEFAULT_LOG_LEVEL, filename=None):
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        sh: logging.StreamHandler = build_stream_handler(level=level)
+        logger.addHandler(sh)
+
+    if filename is not None:
+        fh = build_file_handler(level=level, filename=filename)
+        logger.addHandler(fh)
+
+    return logger
+
+
+def get_formatter():
+    fmt = "[%(levelname)s %(asctime)s %(processName)s %(threadName)s {%(filename)s:%(lineno)d}] %(name)s: %(message)s"
+    formatter = logging.Formatter(fmt=fmt)
+    return formatter
+
+
+# PosixPath('/private/var/folders/10/qs3h5zj10bn52ys456cjq0z40000gn/T/tmpqt74j2js_20240709T180234/run_model.R')
+def build_stream_handler(level: int = DEFAULT_LOG_LEVEL) -> logging.StreamHandler:
+    """Build the default stream handler used for most DRAM logging. Sets
+    default level to INFO, instead of WARNING.
+
+    Args:
+        level: The log level. By default, sets level to INFO
+
+    Returns:
+        A logging.StreamHandler instance
+    """
+    handler = logging.StreamHandler()
+    handler.setLevel(level=level)
+    formatter = get_formatter()
+    handler.setFormatter(formatter)
+    return handler
+
+
+def build_file_handler(filename: os.PathLike, level: int = DEFAULT_LOG_LEVEL) -> logging.FileHandler:
+    handler = logging.FileHandler(filename)
+    handler.setLevel(level=level)
+    formatter = get_formatter()
+    handler.setFormatter(formatter)
+    return handler

--- a/modules/local/annotate/add_sql_descriptions.nf
+++ b/modules/local/annotate/add_sql_descriptions.nf
@@ -5,7 +5,7 @@ process ADD_SQL_DESCRIPTIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:fc59f737a5e0566a"
 
     input:
     tuple val(input_fasta), path(hits_file)

--- a/modules/local/annotate/camper_hmm_formatter.nf
+++ b/modules/local/annotate/camper_hmm_formatter.nf
@@ -4,7 +4,7 @@ process CAMPER_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/canthyd_hmm_formatter.nf
+++ b/modules/local/annotate/canthyd_hmm_formatter.nf
@@ -4,7 +4,7 @@ process CANTHYD_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/combine_annotations.nf
+++ b/modules/local/annotate/combine_annotations.nf
@@ -4,7 +4,7 @@ process COMBINE_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     input:
     val all_annotations

--- a/modules/local/annotate/dbcan_hmm_formatter.nf
+++ b/modules/local/annotate/dbcan_hmm_formatter.nf
@@ -4,7 +4,7 @@ process DBCAN_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
     
     tag { input_fasta }
 
@@ -24,6 +24,5 @@ process DBCAN_HMM_FORMATTER {
 
     sql_add_descriptions.py --hits_csv "${input_fasta}_formatted_dbcan_hits.csv" --db_name ${db_name} --output "${input_fasta}_sql_formatted_${db_name}_hits.csv" --db_file ${ch_sql_descriptions_db}
 
-    
     """
 }

--- a/modules/local/annotate/environment.yml
+++ b/modules/local/annotate/environment.yml
@@ -6,6 +6,6 @@ dependencies:
   - python=3.10
   - pandas=1.5.2
   - hmmer=3.3.2
-  - mmseqs2==15.6f452
+  - mmseqs2==13.45111
   - scikit-bio=0.5.7
   - scipy=1.8.1

--- a/modules/local/annotate/fegenie_hmm_formatter.nf
+++ b/modules/local/annotate/fegenie_hmm_formatter.nf
@@ -4,7 +4,7 @@ process FEGENIE_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/gene_locs.nf
+++ b/modules/local/annotate/gene_locs.nf
@@ -4,7 +4,7 @@ process GENE_LOCS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/generic_hmm_formatter.nf
+++ b/modules/local/annotate/generic_hmm_formatter.nf
@@ -5,7 +5,7 @@ process GENERIC_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     input:
     path( hmm_info_path )

--- a/modules/local/annotate/hmmsearch.nf
+++ b/modules/local/annotate/hmmsearch.nf
@@ -4,7 +4,7 @@ process HMM_SEARCH {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/kegg_hmm_formatter.nf
+++ b/modules/local/annotate/kegg_hmm_formatter.nf
@@ -4,7 +4,7 @@ process KEGG_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/kofam_hmm_formatter.nf
+++ b/modules/local/annotate/kofam_hmm_formatter.nf
@@ -3,7 +3,7 @@ process KOFAM_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/merge_annotations.nf
+++ b/modules/local/annotate/merge_annotations.nf
@@ -4,7 +4,7 @@ process MERGE_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     input:
     path( ch_annotations, stageAs: "annotations/*" )

--- a/modules/local/annotate/mmseqs_index.nf
+++ b/modules/local/annotate/mmseqs_index.nf
@@ -4,7 +4,7 @@ process MMSEQS_INDEX{
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
     
     tag { input_fasta }
 
@@ -16,8 +16,11 @@ process MMSEQS_INDEX{
 
     script:
     """
+    # Create temporary directory
+    mkdir -p mmseqs_out/tmp
 
     mmseqs createdb ${fasta} ${input_fasta}.mmsdb
+    mmseqs createindex ${input_fasta}.mmsdb mmseqs_out/tmp --threads ${params.threads}
 
     """
 

--- a/modules/local/annotate/mmseqs_search.nf
+++ b/modules/local/annotate/mmseqs_search.nf
@@ -6,7 +6,7 @@ process MMSEQS_SEARCH {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag { input_fasta }
 
@@ -23,6 +23,7 @@ process MMSEQS_SEARCH {
 
 
     output:
+    tuple val( input_fasta ), path("mmseqs_out/${input_fasta}_mmseqs_${db_name}.tsv"), emit: mmseqs_search_raw_out, optional: true
     tuple val( input_fasta ), path("mmseqs_out/${input_fasta}_mmseqs_${db_name}_formatted.csv"), emit: mmseqs_search_formatted_out, optional: true
     //tuple val( input_fasta ), path("mmseqs_out/${input_fasta}_mmseqs_rbh_${db_name}.tsv "), emit: mmseqs_search_rbh_formatted_out, optional: true
 
@@ -49,8 +50,7 @@ process MMSEQS_SEARCH {
         # if statement for kegg rbh goes here
     elif [ "${db_name}" == "pfam" ]; then
         # Do profile search:
-        mmseqs search query_database/${input_fasta}.mmsdb ${db_name}.mmspro mmseqs_out/${input_fasta}_${db_name}.mmsdb mmseqs_out/tmp --threads ${params.threads}
-        # -k 5 -s 7
+        mmseqs search query_database/${input_fasta}.mmsdb ${db_name}.mmspro mmseqs_out/${input_fasta}_${db_name}.mmsdb mmseqs_out/tmp -k 5 -s 7  --threads ${params.threads}
 
         # Convert results to BLAST outformat 6
         mmseqs convertalis query_database/${input_fasta}.mmsdb ${db_name}.mmspro mmseqs_out/${input_fasta}_${db_name}.mmsdb mmseqs_out/${input_fasta}_mmseqs_${db_name}.tsv --threads ${params.threads}

--- a/modules/local/annotate/parse_hmmsearch.nf
+++ b/modules/local/annotate/parse_hmmsearch.nf
@@ -4,7 +4,7 @@ process PARSE_HMM {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag{ input_fasta }
     

--- a/modules/local/annotate/sulfur_hmm_formatter.nf
+++ b/modules/local/annotate/sulfur_hmm_formatter.nf
@@ -4,7 +4,7 @@ process SULFUR_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
     
     tag { input_fasta }
 

--- a/modules/local/annotate/vog_hmm_formatter.nf
+++ b/modules/local/annotate/vog_hmm_formatter.nf
@@ -4,18 +4,19 @@ process VOG_HMM_FORMATTER {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:7b4f27307e83be0e"
+    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:4a55e4bf58e4a06b"
 
     tag { input_fasta }
 
     input:
     tuple val( input_fasta ), path( hits_file ), path( prodigal_locs_tsv, stageAs: "gene_locs.tsv" )
-    val( db_name )
+    val(db_name)
     file(ch_sql_descriptions_db)
 
     output:
     tuple val( input_fasta ), path ( "${input_fasta}_formatted_vog_hits.out" ), emit: vog_formatted_hits
     tuple val(input_fasta), path("${input_fasta}_sql_formatted_${db_name}_hits.csv"), emit: sql_formatted_hits
+
 
     script:
     """

--- a/modules/local/collect_rna/trna_scan.nf
+++ b/modules/local/collect_rna/trna_scan.nf
@@ -43,13 +43,13 @@ process TRNA_SCAN {
                 # Add a new FASTA_COLUMN column and populate it with the input_fasta_name value
                 trna_frame.insert(0, FASTA_COLUMN, input_fasta_name)
 
-                # Check if "Note" column is present
-                if "Note" in trna_frame.columns:
-                    # Process the "Note" column to update the "Type" column
-                    trna_frame["Type"] = trna_frame.apply(lambda row: row["Type"] + " (pseudo)" if str(row["Note"]).lower().startswith("pseudo") else row["Type"], axis=1)
+                ## Check if "Note" column is present
+                #if "Note" in trna_frame.columns:
+                #    # Process the "Note" column to update the "Type" column
+                #    trna_frame["Type"] = trna_frame.apply(lambda row: row["Type"] + " (pseudo)" if str(row["Note"]).lower().startswith("pseudo") else row["Type"], axis=1)
 
-                    # Drop the processed "Note" column
-                    trna_frame = trna_frame.drop(columns=["Note"])
+                #    # Drop the processed "Note" column
+                #    trna_frame = trna_frame.drop(columns=["Note"])
 
                 # Keep only the first occurrence of "Begin" and "End" columns
                 trna_frame = trna_frame.loc[:, ~trna_frame.columns.duplicated(keep='first')]
@@ -58,7 +58,7 @@ process TRNA_SCAN {
                 trna_frame = trna_frame.loc[:, ~trna_frame.columns.str.match('(Begin|End)\\.')]
 
                 # Rename specified columns
-                trna_frame = trna_frame.rename(columns={"Name": "query_id", "Begin": "begin", "End": "end", "Type": "type", "Codon": "codon", "Score": "score"})
+                trna_frame = trna_frame.rename(columns={"Name": "query_id", "Begin": "begin", "End": "end", "Type": "type", "Codon": "codon", "Score": "score", "Note": "note"})
 
                 # Create the "gene_id" column by concatenating "type" and "codon"
                 trna_frame["gene_id"] = trna_frame["type"] + " (" + trna_frame["codon"] + ")"

--- a/modules/local/distill/distill.nf
+++ b/modules/local/distill/distill.nf
@@ -4,7 +4,7 @@ process DISTILL {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_openpyxl:20d9b4833f4ee53c"
+    container "community.wave.seqera.io/library/python_pandas_openpyxl_click:71fdc06a3fdfbdc1"
 
     input:
     path( ch_combined_annotations, stageAs: "raw-annotations.tsv" )

--- a/modules/local/distill/distill.nf
+++ b/modules/local/distill/distill.nf
@@ -8,23 +8,20 @@ process DISTILL {
 
     input:
     path( ch_combined_annotations, stageAs: "raw-annotations.tsv" )
-    path( ch_combined_distill_sheets, stageAs: "combined/*" )
-    path( ch_target_id_counts, stageAs: "target_id_counts.tsv")
-    path( ch_quast_stats, stageAs: "collected_quast.tsv" )
-    path( ch_rrna_sheet, stageAs: "rrna_sheet.tsv" )
-    path( ch_combined_rrna, stageAs: "rrna_combined.tsv" )
-    path( ch_trna_sheet, stageAs: "trna_sheet.tsv" )
-    path( annotations_sqlite3 )
+    path( ch_rrna_combined, stageAs: "rrna_combined.tsv" )
+    path( ch_trna_combined, stageAs: "trna_combined.tsv" )
 
     output:
     path( "distillate.xlsx" ), emit: distillate
+    path( "dram.log" ), emit: distill_log
+    path( "summarized_genomes.tsv" ), emit: summarized_genomes
 
     script:
     """
     # export constants for script
     export FASTA_COLUMN="${params.CONSTANTS.FASTA_COLUMN}"
 
-    distill_xlsx.py --target_id_counts ${ch_target_id_counts} --db_name ${annotations_sqlite3} --distill_sheets combined/*.tsv --rrna_file ${ch_rrna_sheet} --combined_rrna_file ${ch_combined_rrna} --trna_file ${ch_trna_sheet} --quast ${ch_quast_stats} --output_file "distillate.xlsx" --threads ${params.threads}
+    distill.py -i ${ch_combined_annotations} --rrna_path ${ch_rrna_combined} --trna_path ${ch_trna_combined} --distil_topics "${params.distill_topic}" --distil_ecosystem "${params.distill_ecosystem}" --custom_distillate "${params.distill_custom}"
 
     """
 }

--- a/modules/local/distill/environment.yml
+++ b/modules/local/distill/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - python=3.10
   - pandas=1.5.2
   - openpyxl=3.1.2
+  - click<9.0

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,7 @@ params {
     use_pfam = false
     use_merops = false
     use_uniref = false
-    // use_vog = false  // TODO: Add vog annotation
+    use_vog = false  // TODO: Add vog annotation
     // use_viral = false  // TODO: Add viral annotation
 
     add_annotations = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -40,7 +40,7 @@
                 },
                 "distill_custom": {
                     "type": "string",
-                    "description": "<path/to/custom_distillate.tsv>  Custom distill file to use."
+                    "description": "<path/to/custom_distillate.tsv>  Custom distill file to use. Can also supply a comma separated list of custom distill files to use. If more than one file included, they must be seperated by a comma (--distill_custom path/to/file1.tsv,path/to/file2.tsv or --distill_custom 'file1.tsv,file2.tsv'). The custom distill file must be in TSV format with the first column being the gene ID and the second column being the distillate value."
                 },
                 "product": {
                     "type": "boolean",
@@ -48,7 +48,7 @@
                 },
                 "adjectives": {
                     "type": "boolean",
-                    "description": "Using a DRAM annotations file, make a table of adjectives."
+                    "description": "Using a DRAM annotations file, make a table of adjectives. Still in development, but can still be used."
                 },
                 "format_kegg": {
                     "type": "boolean",
@@ -211,7 +211,7 @@
                 },
                 "use_pfam": {
                     "type": "boolean",
-                    "description": "Use the PFAM database for annotation."
+                    "description": "Use the PFAM database for annotation. Currently disabled for this release as a bug was discovered with the pfam DRAM2 implementation. It will be re-enabled in the next release."
                 },
                 "use_sulfur": {
                     "type": "boolean",

--- a/subworkflows/local/add_and_count.nf
+++ b/subworkflows/local/add_and_count.nf
@@ -50,6 +50,7 @@ workflow ADD_AND_COUNT {
         ch_updated_taxa_annots = ch_combined_annotations
     }
 
+    ch_final_annots = ch_updated_taxa_annots
     // Check for additional user-provided annotations
     if( params.add_annotations ){
         ch_add_annots = file(params.add_annotations)
@@ -61,21 +62,23 @@ workflow ADD_AND_COUNT {
         //     TREES( ch_final_annots, params.trees_list, ch_collected_faa, ch_tree_data_files, ch_trees_scripts, ch_add_trees )
         // }
 
-        COUNT_ANNOTATIONS ( ch_final_annots )
-        ch_annotation_counts = COUNT_ANNOTATIONS.out.target_id_counts
-        ch_annotations_sqlite3 = COUNT_ANNOTATIONS.out.annotations_sqlite3
+
+        // Not running count after changing distill to not use sql db built here, remove soon once sure
+        // COUNT_ANNOTATIONS ( ch_final_annots )
+        // ch_annotation_counts = COUNT_ANNOTATIONS.out.target_id_counts
+        // ch_annotations_sqlite3 = COUNT_ANNOTATIONS.out.annotations_sqlite3
     }
-    else{
+    // else{
         // If the user wants to run trees, do it before we count the annotations
         // if( params.trees ){
         //     TREES( ch_updated_taxa_annots, params.trees_list, ch_collected_faa, ch_tree_data_files, ch_trees_scripts, ch_add_trees )
         // }
 
-        ch_final_annots = ch_updated_taxa_annots
-        COUNT_ANNOTATIONS ( ch_final_annots )
-        ch_annotation_counts = COUNT_ANNOTATIONS.out.target_id_counts
-        ch_annotations_sqlite3 = COUNT_ANNOTATIONS.out.annotations_sqlite3
-    }
+        // ch_final_annots = ch_updated_taxa_annots
+        // COUNT_ANNOTATIONS ( ch_final_annots )
+        // ch_annotation_counts = COUNT_ANNOTATIONS.out.target_id_counts
+        // ch_annotations_sqlite3 = COUNT_ANNOTATIONS.out.annotations_sqlite3
+    // }
 
     if( params.generate_gff || params.generate_gbk ){
 
@@ -99,7 +102,5 @@ workflow ADD_AND_COUNT {
 
     emit:
     ch_final_annots
-    ch_annotation_counts
-    ch_annotations_sqlite3
 
 }

--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -273,7 +273,7 @@ workflow ANNOTATE {
         formattedOutputChannels = formattedOutputChannels.mix(ch_uniref_formatted)
     }
     // VOGdb annotation
-    if (params.use_vogdb) {
+    if (params.use_vog) {
         HMM_SEARCH_VOG ( ch_called_proteins, params.vog_e_value , DB_CHANNEL_SETUP.out.ch_vogdb_db )
         ch_vog_hmms = HMM_SEARCH_VOG.out.hmm_search_out
 
@@ -403,7 +403,7 @@ workflow DB_CHANNEL_SETUP {
         ch_canthyd_mmseqs_list = file(params.canthyd_mmseqs_list)
     }
 
-    if (params.use_vogdb) {
+    if (params.use_vog) {
         ch_vogdb_db = file(params.vog_db).exists() ? file(params.vog_db) : error("Error: If using --annotate, you must supply prebuilt databases. VOG database file not found at ${params.vog_db}")
     }
 

--- a/subworkflows/local/collect_rna.nf
+++ b/subworkflows/local/collect_rna.nf
@@ -60,6 +60,7 @@ workflow COLLECT_RNA {
     // Run TRNA_COLLECT to generate a combined TSV for all fastas
     TRNA_COLLECT( ch_collected_tRNAs )
     ch_trna_sheet = TRNA_COLLECT.out.trna_collected_out
+    ch_trna_combined = TRNA_COLLECT.out.trna_combined_out
 
     // Create sheet for rrnas from the collected rRNAs or provided rRNAs
     // Run RRNA_COLLECT to generate a combined TSV for all fastas
@@ -72,5 +73,6 @@ workflow COLLECT_RNA {
     ch_rrna_sheet
     ch_rrna_combined
     ch_trna_sheet
+    ch_trna_combined
 
 }

--- a/subworkflows/local/distill.nf
+++ b/subworkflows/local/distill.nf
@@ -19,32 +19,16 @@ include { COMBINE_DISTILL                                   } from "${projectDir
 
 workflow DISTILL {
     take:
-    ch_distill_carbon
-    ch_distill_energy
-    ch_distill_misc
-    ch_distill_nitrogen
-    ch_distill_transport
-    ch_distill_ag
-    ch_distill_eng_sys
-    ch_distill_camper
-    ch_distill_custom_collected
     ch_final_annots
-    ch_annotation_counts
-    ch_rrna_sheet
-    ch_quast_stats
     ch_rrna_combined
-    ch_trna_sheet
-    ch_annotations_sqlite3
+    ch_trna_combined
+
 
     main:
 
-    // Combine the individual user-specified distill sheets into a single channel
-    COMBINE_DISTILL(ch_distill_carbon, ch_distill_energy, ch_distill_misc, ch_distill_nitrogen, ch_distill_transport, ch_distill_ag, ch_distill_eng_sys, ch_distill_camper, ch_distill_custom_collected )
-    ch_combined_distill_sheets = COMBINE_DISTILL.out.ch_combined_distill_sheets
-
     // Generate multi-sheet XLSX document containing annotations included in user-specified distillate speadsheets
 
-    DISTILL_SCRIPT( ch_final_annots, ch_combined_distill_sheets, ch_annotation_counts, ch_quast_stats, ch_rrna_sheet, ch_rrna_combined, ch_trna_sheet, ch_annotations_sqlite3 )
+    DISTILL_SCRIPT( ch_final_annots, ch_rrna_combined, ch_trna_combined )
     ch_distillate = DISTILL_SCRIPT.out.distillate
 
 

--- a/subworkflows/local/utils_nfcore_dram_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_dram_pipeline/main.nf
@@ -83,6 +83,10 @@ workflow PIPELINE_INITIALISATION {
         error("When using Adjectives, make sure you use Kegg, FeGenie, and Sulfur Databases")
     }
 
+    if (params.use_pfam) {
+        error("PFAM database is currently disabled in this pipeline due to a bug in the DRAM2 implementation with the PFAM database. It will be re-enabled in the next release.")
+    }
+
     //
     // Validate parameters and generate parameter summary to stdout
     //

--- a/workflows/dram.nf
+++ b/workflows/dram.nf
@@ -82,101 +82,7 @@ workflow DRAM {
                 }
 
                 // Handle the 'default' case by setting all default topics to "1"
-                if (topic == "default") {
-                    distill_default = "1"
-                    distill_carbon = "1"
-                    distill_energy = "1"
-                    distill_misc = "1"
-                    distill_nitrogen = "1"
-                    distill_transport = "1"
-
-                    if (params.use_camper) {
-                        distill_camper = "1"
-                    }
-                    // Ensure that default topics are listed only once
-                    if (!distill_topic_list.contains("default")) {
-                        distill_topic_list += "default (carbon, energy, misc, nitrogen, transport) "
-                    }
-                } else {
-                    // Handle other topics
-                    switch (topic) {
-                        case "carbon":
-                            distill_carbon = "1"
-                            if (!distill_topic_list.contains("carbon")) distill_topic_list += "carbon "
-                            break
-                        case "energy":
-                            distill_energy = "1"
-                            if (!distill_topic_list.contains("energy")) distill_topic_list += "energy "
-                            break
-                        case "misc":
-                            distill_misc = "1"
-                            if (!distill_topic_list.contains("misc")) distill_topic_list += "misc "
-                            break
-                        case "nitrogen":
-                            distill_nitrogen = "1"
-                            if (!distill_topic_list.contains("nitrogen")) distill_topic_list += "nitrogen "
-                            break
-                        case "transport":
-                            distill_transport = "1"
-                            if (!distill_topic_list.contains("transport")) distill_topic_list += "transport "
-                            break
-                        case "camper":
-                            distill_camper = "1"
-                            if (!distill_topic_list.contains("camper")) distill_topic_list += "camper "
-                            break
-                    }
-                }
             }
-
-            // Remove the default placeholder if other topics were added in addition to default
-            if (distill_default == "1" && topics.size() > 1) {
-                distill_topic_list = distill_topic_list.replace("default (carbon, energy, misc, nitrogen, transport) ", "")
-                if (!distill_topic_list.contains("carbon")) distill_topic_list = "carbon, energy, misc, nitrogen, transport, " + distill_topic_list.trim()
-            }
-        }
-
-        if (distill_carbon == "1") {
-            ch_distill_carbon = file(params.distill_carbon_sheet).exists() ? file(params.distill_carbon_sheet) : error("Error: If using --distill_topic carbon (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_carbon = default_sheet
-        }
-        if (distill_energy == "1") {
-            ch_distill_energy = file(params.distill_energy_sheet).exists() ? file(params.distill_energy_sheet) : error("Error: If using --distill_topic energy (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_energy = default_sheet
-        }
-
-        if (distill_misc == "1") {
-            ch_distill_misc = file(params.distill_misc_sheet).exists() ? file(params.distill_misc_sheet) : error("Error: If using --distill_topic misc (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_misc = default_sheet
-        }
-
-        if (distill_nitrogen == "1") {
-            ch_distill_nitrogen = file(params.distill_nitrogen_sheet).exists() ? file(params.distill_nitrogen_sheet) : error("Error: If using --distill_topic nitrogen (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_nitrogen = default_sheet
-        }
-
-        if (distill_transport == "1") {
-            ch_distill_transport = file(params.distill_transport_sheet).exists() ? file(params.distill_transport_sheet) : error("Error: If using --distill_topic transport (or 'default'), you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_transport = default_sheet
-        }
-
-        if (distill_camper == "1") {
-            ch_distill_camper = file(params.distill_camper_sheet).exists() ? file(params.distill_camper_sheet) : error("Error: If using --distill_topic camper, you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-            if (!params.use_camper) {
-                error("Error: If using --distill_topic camper, you must also use --use_camper.")
-            }
-
-        } else{
-            ch_distill_camper = default_sheet
         }
 
         distill_eng_sys = "0"
@@ -192,32 +98,9 @@ workflow DRAM {
                     error("Invalid distill ecosystem: $ecosysItem. Valid values are eng_sys, ag")
                 }
 
-                switch (ecosysItem) {
-                    case "ag":
-                        distill_ag = "1"
-                        distill_ecosystem_list = distill_ecosystem_list + "ag "
-                        break
-                    case "eng_sys":
-                        distill_eng_sys = "1"
-                        distill_ecosystem_list = distill_ecosystem_list + "eng_sys "
-                        break
-                }
             }
         }
 
-        if (distill_eng_sys == "1") {
-            ch_distill_eng_sys = file(params.distill_eng_sys_sheet).exists() ? file(params.distill_eng_sys_sheet) : error("Error: If using --distill_ecosystem eng_sys, you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_eng_sys = default_sheet
-        }
-
-        if (distill_ag == "1") {
-            ch_distill_ag = file(params.distill_ag_sheet).exists() ? file(params.distill_ag_sheet) : error("Error: If using --distill_ecosystem ag, you must have the preformatted distill sheets in ./assets/forms/distill_sheets.")
-
-        } else{
-            ch_distill_ag = default_sheet
-        }
         /*
         if (params.distill_custom != "") {
             ch_distill_custom = file(params.distill_custom).exists() ? file(params.distill_custom) : error("Error: If using --distill_custom <path/to/TSV>, you must have the preformatted custom distill sheet in the provided file: ${params.distill_custom}.")
@@ -227,34 +110,18 @@ workflow DRAM {
         }
         */
         if (params.distill_custom != "") {
-        // Verify the directory exists
-        def custom_distill_dir = file(params.distill_custom)
-        if (!custom_distill_dir.exists()) {
-            error "Error: The specified directory for merging annotations (--distill_custom) does not exist: ${params.distill_custom}"
-        }
-        else{
-            ch_distill_custom_collected = default_sheet
-        }
+            // Verify the directory exists
+            def custom_distill_dir = file(params.distill_custom)
+            if (!custom_distill_dir.exists()) {
+                error "Error: The specified directory for merging annotations (--distill_custom) does not exist: ${params.distill_custom}"
+            }
 
-        // Verify the directory contains .tsv files
-        def tsv_files = custom_distill_dir.list().findAll { it.endsWith('.tsv') }
-        if (tsv_files.isEmpty()) {
-            error "Error: The specified directory for merging annotations (--distill_custom) does not contain any .tsv files: ${params.distill_custom}"
-        }
-        else{
-                // Create a channel with the paths to the .tsv files
-        Channel
-            .from(tsv_files.collect { custom_distill_dir.toString() + '/' + it })
-            .set { ch_distill_custom }
-        Channel.empty()
-            .mix( ch_distill_custom )
-            .collect()
-            .set { ch_distill_custom_collected }
-
-        }
-        }
-        else{
-            ch_distill_custom_collected = default_sheet
+            // Verify the directory contains .tsv files
+            def tsv_files = custom_distill_dir.list().findAll { it.endsWith('.tsv') }
+            if (tsv_files.isEmpty()) {
+                error "Error: The specified directory for merging annotations (--distill_custom) does not contain any .tsv files: ${params.distill_custom}"
+            }
+        
         }
 
         if (!params.use_kegg && !params.use_kofam && !params.use_dbcan && !params.use_merops) {
@@ -360,22 +227,9 @@ workflow DRAM {
 
             if( distill_flag ){
                 DISTILL(
-                    ch_distill_carbon,
-                    ch_distill_energy,
-                    ch_distill_misc,
-                    ch_distill_nitrogen,
-                    ch_distill_transport,
-                    ch_distill_ag,
-                    ch_distill_eng_sys,
-                    ch_distill_camper,
-                    ch_distill_custom_collected,
                     ch_final_annots,
-                    ADD_AND_COUNT.out.ch_annotation_counts,
-                    COLLECT_RNA.out.ch_rrna_sheet,
-                    ch_quast_stats,
                     COLLECT_RNA.out.ch_rrna_combined,
-                    COLLECT_RNA.out.ch_trna_sheet,
-                    ADD_AND_COUNT.out.ch_annotations_sqlite3
+                    COLLECT_RNA.out.ch_trna_combined,
                 )
             }
 


### PR DESCRIPTION
[Rework distill to DRAM1 version](https://github.com/WrightonLabCSU/DRAM/commit/0c5a99af5d4a943d571c96b141eacce95877373b) 
DRAM2's implementaiton of Distill utilized a sql db that was build up,
this db wasn't always the same as the raw annotaiton file, wasn't necessaryly faster
and added extra scheduelr jobs, so it was removed and repalced with the DRAM1 implementation.
The DRAM1 implementaiton takes the raw annotation file and does the calculation right
on that.

Removed the target count ids output as well since it was mostly used for the sql db distill
step.

Need to add back in the distill overview page that is from quast, ideally.

Removed pfam for now because of a bug of using mmseqs >=15 requires rebuilding profile db,
annotation code I believe was designed around compensating for the many to many
output that was being created (output file from mmseqs step with pfam was ~80-100 mb instead of
1/2 mb like it should have been), so remove pfam until next release when code is fixed and
maybe we can try out mseqs 17 even for faster queries.