### PR TITLE
Add slurm_node config option (nodelist)

### DIFF
--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -12,6 +12,7 @@ process {
   ]
   executor = 'slurm'
   queue    = params.partition
+  clusterOptions = (params.slurm_node ? "--nodelist=${params.slurm_node} " : "")
 }
 executor {
   queueSize = params.queue_size

--- a/nextflow.config
+++ b/nextflow.config
@@ -145,6 +145,7 @@ params {
     /* SLURM options */
     slurm = false
     partition = null
+    slurm_node = null
     queue_size = 10
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -613,6 +613,10 @@
                     "type": "string",
                     "description": "Name of the SLURM partition to use for job submission. If not provided, the default partition will be used."
                 },
+                "slurm_node": {
+                    "type": "string",
+                    "description": "Name of the SLURM Node to use for job submission. If not provided, the default node will be used.",
+                },
                 "queue_size": {
                     "type": "integer",
                     "default": 10,


### PR DESCRIPTION
# Summary

Add option to configure slurm nodelist in the configuration for your slurm options. If you want DRAM to handle a basic slurm implementation, it can now do a slurm nodelist by name as well as the partition. More comlicated slurm implementations may need custom slurm configuration or more options in the future.