### PR TITLE
Allow job limits (cpu, mem, time) be controlled by config

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -27,47 +27,34 @@ process {
     // TODO nf-core: Customise requirements for specific processes.
     // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel:process_tiny {
-        cpus   = { 1                   }
-        memory = { 1.GB * task.attempt }
-        time   = { 1.h  * task.attempt }
+        cpus   = { params.tiny_cpus_limit                   }
+        memory = { params.tiny_gb_mem_limit.GB * task.attempt }
+        time   = { params.tiny_hr_time_limit.h  * task.attempt }
     }
     withLabel:process_single {
         cpus   = { 1                   }
-        memory = { 6.GB * task.attempt }
-        time   = { 4.h  * task.attempt }
+        memory = { params.small_gb_mem_limit.GB * task.attempt }
+        time   = { params.small_hr_time_limit.h  * task.attempt }
     }
     withLabel:process_small {
-        cpus   = { 2     * task.attempt }
-        memory = { 12.GB * task.attempt }
-        time   = { 4.h   * task.attempt }
+        cpus   = { params.small_cpus_limit     * task.attempt }
+        memory = { params.small_gb_mem_limit.GB * task.attempt }
+        time   = { params.small_hr_time_limit.h   * task.attempt }
     }
     withLabel:process_medium {
-        cpus   = { 6     * task.attempt }
-        memory = { 24.GB * task.attempt }
-        time   = { 8.h   * task.attempt }
+        cpus   = { params.medium_cpus_limit     * task.attempt }
+        memory = { params.medium_gb_mem_limit.GB * task.attempt }
+        time   = { params.medium_hr_time_limit.h   * task.attempt }
     }
     withLabel:process_big {
-        cpus   = { 12    * task.attempt }
-        memory = { 72.GB * task.attempt }
-        time   = { 16.h  * task.attempt }
+        cpus   = { params.big_cpus_limit    * task.attempt }
+        memory = { params.big_gb_mem_limit.GB * task.attempt }
+        time   = { params.big_hr_time_limit.h  * task.attempt }
     }
-    withLabel:process_long {
-        time   = { 20.h  * task.attempt }
-    }
-    withLabel:process_day {
-        time   = { 1.day  * task.attempt }
-    }
-    withLabel:process_week {
-        time   = { 7.day  * task.attempt }
-    }
-    withLabel:process_short {
-        time   = { 30.m  * task.attempt }
-    }
-    withLabel:process_single_cpu {
-        cpus   = { 1                    }
-    }
-    withLabel:process_big_memory {
-        memory = { 200.GB * task.attempt }
+    withLabel:process_huge {
+        cpus   = { params.huge_cpus_limit    * task.attempt }
+        memory = { params.huge_gb_mem_limit.GB * task.attempt }
+        time   = { params.huge_hr_time_limit.h  * task.attempt }
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -6,9 +6,12 @@ params {
 
 process {
   resourceLimits = [
-    cpus: 128,
-    memory: 2.TB,
-    time: 14.day
+    // cpus: 128,
+    cpus: params.cpu_provision_limit ? params.cpu_provision_limit : params.huge_cpus_limit,
+    memory: params.mem_gb_provision_limit ? params.mem_gb_provision_limit.GB : params.huge_gb_mem_limit.GB,
+    time: params.time_hr_provision_limit ? params.time_hr_provision_limit.h : params.huge_hr_time_limit.h
+    // memory: 2.TB,
+    // time: 14.day
   ]
   executor = 'slurm'
   queue    = params.partition

--- a/modules/local/annotate/add_sql_descriptions.nf
+++ b/modules/local/annotate/add_sql_descriptions.nf
@@ -1,6 +1,5 @@
 process ADD_SQL_DESCRIPTIONS {
-    label 'process_medium'
-    label 'process_single_cpu'
+    label 'process_single'
 
     errorStrategy 'finish'
 

--- a/modules/local/annotate/mmseqs_search.nf
+++ b/modules/local/annotate/mmseqs_search.nf
@@ -1,7 +1,5 @@
 process MMSEQS_SEARCH {
-    label 'process_big'
-    label 'process_week'
-    label 'process_big_memory'
+    label 'process_huge'
 
     errorStrategy 'finish'
 

--- a/modules/local/database/format_kegg_db.nf
+++ b/modules/local/database/format_kegg_db.nf
@@ -1,6 +1,5 @@
 process FORMAT_KEGG_DB {
-    label 'process_big'
-    label 'process_big_memory'
+    label 'process_huge'
 
     errorStrategy 'finish'
 

--- a/modules/local/rename/rename_fasta.nf
+++ b/modules/local/rename/rename_fasta.nf
@@ -1,6 +1,5 @@
 process RENAME_FASTA {
     label 'process_tiny'
-    label 'process_short'
 
     tag { "renaming_fastas" }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -175,7 +175,7 @@ params {
     small_hr_time_limit = 4
     medium_hr_time_limit = 8
     big_hr_time_limit = 16
-    huge_hr_time_limit = 72  // For very large genomes, you may need to increase this
+    huge_hr_time_limit = 168  // For very large genomes, you may need to increase this
 
 
     /* MultiQC options */

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -36,7 +36,6 @@
                 "distill_ecosystem": {
                     "type": "string",
                     "description": "Ecosystem to distill. Options: <eng_sys|ag> If more than one ecosystem included, they must be seperated by a comma (--distill_ecosystem eng_sys,ag or --distill_ecosystem 'eng_sys,ag')."
-
                 },
                 "distill_custom": {
                     "type": "string",
@@ -111,7 +110,6 @@
                     "fa_,icon": "fas fa-plus"
                 }
             }
-
         },
         "call_prodigal_options": {
             "title": "Call Prodigal Options",
@@ -221,6 +219,9 @@
                     "type": "boolean",
                     "description": "Use the UniRef database for annotation."
                 },
+                "use_vog": {
+                    "type": "boolean"
+                },
                 "add_annotations": {
                     "type": "string",
                     "format": "file-path",
@@ -293,7 +294,6 @@
                     "type": "string",
                     "description": "Column to to group by in the annotations file for etc and function groupings. Defaults to DRAM's annotation output fasta column name."
                 }
-
             }
         },
         "adjectives_options": {
@@ -306,7 +306,6 @@
                     "type": "string",
                     "description": "A comma seperated list of adjectives ('adj1,adj2,adj3'), by name, to evaluate. This limits the number of adjectives that are evaluated and is faster."
                 }
-
             }
         },
         "bin_and_taxa_options": {
@@ -349,7 +348,6 @@
                     "type": "string",
                     "default": "${launchDir}/databases/pfam/mmseqs/",
                     "hidden": true
-
                 },
                 "merops_db": {
                     "type": "string",
@@ -559,7 +557,6 @@
                 "slurm": {
                     "type": "boolean",
                     "description": "Launch the pipeline using the SLURM executor. Without this option, the pipeline will run in your current shell/environment."
-
                 },
                 "partition": {
                     "type": "string",
@@ -568,9 +565,21 @@
                 "slurm_node": {
                     "type": "string",
                     "description": "Name of the SLURM Node to use for job submission. If not provided, the default node will be used."
+                },
+                "cpu_provision_limit": {
+                    "type": "string",
+                    "description": "The largest numbers of CPUs you can provision in 1 job. Not the total CPU limit. You can control that with process size or provision limit and queue_size"
+                },
+                "mem_gb_provision_limit": {
+                    "type": "string",
+                    "description": "The largest amount of memory you can provision in 1 job. Not the total memory limit. You can control that with process size or provision limit and queue_size"
+                },
+                "time_hr_provision_limit": {
+                    "type": "string",
+                    "description": "The longest time a job should be provisioned for. Not the total length cutoff for all jobs. You can control that with process size or provision limit and queue_size"
                 }
             }
-        },        
+        },
         "process_options": {
             "title": "Process Options",
             "type": "object",
@@ -579,8 +588,63 @@
             "properties": {
                 "tiny_cpus_limit": {
                     "type": "integer",
-                    "default": 1,
-                    "description": "Maximum number of CPUs to use/provision for a tiny labeled process. This is the smallest process size and is used for processes that do not require much CPU power."
+                    "description": "Maximum number of CPUs to use/provision for a this job size."
+                },
+                "small_cpus_limit": {
+                    "type": "integer",
+                    "description": "Maximum number of CPUs to use/provision for a this job size."
+                },
+                "medium_cpus_limit": {
+                    "type": "integer",
+                    "description": "Maximum number of CPUs to use/provision for a this job size."
+                },
+                "big_cpus_limit": {
+                    "type": "integer",
+                    "description": "Maximum number of CPUs to use/provision for a this job size."
+                },
+                "huge_cpus_limit": {
+                    "type": "integer",
+                    "description": "Maximum number of CPUs to use/provision for a this job size."
+                },
+                "tiny_gb_mem_limit": {
+                    "type": "integer",
+                    "description": "Maximum memory to use/provision for a this job size."
+                },
+                "small_gb_mem_limit": {
+                    "type": "integer",
+                    "description": "Maximum memory to use/provision for a this job size."
+                },
+                "medium_gb_mem_limit": {
+                    "type": "integer",
+                    "description": "Maximum memory to use/provision for a this job size."
+                },
+                "big_gb_mem_limit": {
+                    "type": "integer",
+                    "description": "Maximum memory to use/provision for a this job size."
+                },
+                "huge_gb_mem_limit": {
+                    "type": "integer",
+                    "description": "Maximum memory to use/provision for a this job size."
+                },
+                "tiny_hr_time_limit": {
+                    "type": "integer",
+                    "description": "Maximum time in hours to use/provision for a this job size."
+                },
+                "small_hr_time_limit": {
+                    "type": "integer",
+                    "description": "Maximum time in hours to use/provision for a this job size."
+                },
+                "medium_hr_time_limit": {
+                    "type": "integer",
+                    "description": "Maximum time in hours to use/provision for a this job size."
+                },
+                "big_hr_time_limit": {
+                    "type": "integer",
+                    "description": "Maximum time in hours to use/provision for a this job size."
+                },
+                "huge_hr_time_limit": {
+                    "type": "integer",
+                    "description": "Maximum time in hours to use/provision for a this job size."
                 },
                 "queue_size": {
                     "type": "integer",
@@ -679,7 +743,6 @@
                     "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
                     "hidden": true
                 },
-
                 "email_on_fail": {
                     "type": "string",
                     "description": "Email address for completion summary, only when pipeline fails.",
@@ -799,7 +862,7 @@
         },
         {
             "$ref": "#/defs/slurm_options"
-        },        
+        },
         {
             "$ref": "#/defs/process_options"
         },


### PR DESCRIPTION
Allow all job limits of various sizes as well as max SLURM resource limit setting be set in main config instead of having to do more complicated configuration stuff for users.