### PR TITLE
feat: streamline TRNA_COLLECT proccess

### DIFF
--- a/bin/trna_collect.py
+++ b/bin/trna_collect.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import os
+import pandas as pd
+from pathlib import Path
+
+FASTA_COLUMN = os.getenv('FASTA_COLUMN')
+
+df = pd.read_csv(Path("combined_trna_scan.tsv").resolve(), sep='\t')
+
+gene_col="gene_id"
+df = df[[FASTA_COLUMN, gene_col]].copy()
+counts = pd.crosstab(df[gene_col], df[FASTA_COLUMN], dropna=False).astype("int64")
+counts.columns.name = None
+counts = counts.reset_index()
+counts["gene_description"] = counts[gene_col] + " tRNA"
+counts["category"] = "tRNA"
+counts["topic_ecosystem"] = "tRNA"
+counts["subcategory"] = ""
+
+counts.to_csv("collected_trnas.tsv", sep="\t", index=False)

--- a/modules/local/collect_rna/trna_collect.nf
+++ b/modules/local/collect_rna/trna_collect.nf
@@ -17,79 +17,11 @@ process TRNA_COLLECT {
 
     script:
     """
-    #!/usr/bin/env python
+    # export constants for script
+    export FASTA_COLUMN="${params.CONSTANTS.FASTA_COLUMN}"
 
-    import os
-    import pandas as pd
+    awk '(NR==1) || (FNR>1)' *processed_trnas.tsv > combined_trna_scan.tsv
 
-    FASTA_COLUMN="${params.CONSTANTS.FASTA_COLUMN}"
-
-    # Function to check if file content is "NULL"
-    def file_content_is_null(filename):
-        with open(filename, 'r') as file:
-            content = file.read().strip()
-        return content == "NULL"
-
-    # List all tsv files in the current directory
-    tsv_files = [f for f in os.listdir('.') if f.endswith('.tsv')]
-
-    # Check if all files contain "NULL"
-    all_files_null = all(file_content_is_null(file) for file in tsv_files)
-
-    if all_files_null:
-        # If all files contain "NULL", write "NULL" to the output and exit
-        with open("collected_trnas.tsv", "w") as output_file:
-            output_file.write("NULL")
-    else:
-        # Filter out files with "NULL" content
-        tsv_files = [file for file in tsv_files if not file_content_is_null(file)]
-
-        # Extract input_fasta names from the file names
-        input_fastas = [os.path.basename(file).replace("_processed_trnas.tsv", "") for file in tsv_files]
-
-        # Create an empty DataFrame to store the collected data
-        collected_data = pd.DataFrame(columns=["gene_id", "gene_description", "category", "topic_ecosystem", "subcategory"] + input_fastas)
-
-        # Create a dictionary to store counts for each input_fasta
-        input_fasta_counts = {input_fasta: [] for input_fasta in input_fastas}
-
-        combined_data = []
-
-        # Iterate through each input file
-        for file in tsv_files:
-            # Read the input file into a DataFrame
-            input_data = pd.read_csv(file, sep='\t')
-
-            # Populate the gene_id column
-            collected_data = pd.concat([collected_data, input_data[['gene_id']].drop_duplicates()], ignore_index=True)
-
-            # Count occurrences for each input_fasta
-            for input_fasta in input_fastas:
-                input_fasta_counts[input_fasta].extend(input_data[input_data[FASTA_COLUMN] == input_fasta]['gene_id'])
-
-            combined_data.append(input_data)
-
-        # Deduplicate the rows based on gene_id
-        collected_data.drop_duplicates(subset=['gene_id'], inplace=True)
-
-        # Populate gene_description and category using gene_id
-        # Assuming gene_description is "gene_id tRNA"
-        # Assuming category is simply "tRNA"
-        collected_data['gene_description'] = collected_data['gene_id'].apply(lambda x: x + " tRNA")
-        collected_data['category'] = "tRNA"
-        collected_data['topic_ecosystem'] = "tRNA"
-        collected_data['subcategory'] = ""  # Assuming subcategory is not defined
-
-        # Count occurrences for each input_fasta and fill the additional columns dynamically
-        for input_fasta in input_fastas:
-            collected_data[input_fasta] = collected_data['gene_id'].map(lambda x: input_fasta_counts[input_fasta].count(x) if x in input_fasta_counts[input_fasta] else 0)
-
-        # Sort the whole table by the gene_id column
-        collected_data.sort_values(by='gene_id', inplace=True)
-
-        # Write the collected data to the output file
-        collected_data.to_csv("collected_trnas.tsv", sep="\t", index=False)
-        combined_df = pd.concat(combined_data, ignore_index=True)
-        combined_df.to_csv('combined_trna_scan.tsv', sep='\\t', index=False)
+    trna_collect.py
     """
 }

--- a/modules/local/collect_rna/trna_scan.nf
+++ b/modules/local/collect_rna/trna_scan.nf
@@ -67,18 +67,9 @@ process TRNA_SCAN {
                 if not trna_frame.empty:
                     # Write the processed DataFrame to the output file
                     trna_frame.to_csv(output_file, sep="\t", index=False)
-                else:
-                    # DataFrame is empty after processing, write "NULL" to output
-                    with open(output_file, "w") as f:
-                        f.write("NULL")
-            else:
-                # Initial DataFrame is empty, write "NULL" to output
-                with open(output_file, "w") as f:
-                    f.write("NULL")
         except pd.errors.EmptyDataError:
             # The input file is empty or only contains headers, write "NULL" to output
-            with open(output_file, "w") as f:
-                f.write("NULL")
+            pass
 
     # Run tRNAscan-SE with the necessary input to avoid prompts
     trna_out = "${input_fasta}_trna_out.txt"


### PR DESCRIPTION
rewrite TRNA_COLLECT to use pandas vectorized functions instead of embedded for loops to significantly streamline creation of collected_trnas.tsv with large # of inputs. Now instead of taking hours or days, it will run in seconds or minutes.