### PR TITLE
package(api): add full_mode to profiles to run all options

### DIFF
--- a/bin/generate_gff_genbank.py
+++ b/bin/generate_gff_genbank.py
@@ -25,7 +25,7 @@ def parse_arguments():
     parser.add_argument("--database_list", type=str, help="Comma-separated list of databases to include in the annotations. Use 'empty' for all.", default="empty")
     parser.add_argument("--annotations", required=True, help="Path to the raw annotations file")
     args = parser.parse_args()
-    args.database_list = None if args.database_list == "empty" else args.database_list.split(',')
+    args.database_list = None if (args.database_list == "empty" or args.database_list == "all") else args.database_list.split(',')
     return args
 
 def parse_input_fastas_and_paths(input_fastas_paths):

--- a/conf/test.config
+++ b/conf/test.config
@@ -31,34 +31,17 @@ params {
     // distill_ecosystem   = 'eng_sys,ag'
     // product             = true
     // adjectives          = true
-    use_merops          = true
+    // use_merops          = true
     // use_fegenie         = true
     // use_sulfur          = true
     // use_camper          = true
-    use_kofam           = true
-    use_kegg            = true
-    slurm               = true
-    use_dbcan           = true
+    // use_kofam           = true
+    // use_kegg            = true
+    // use_dbcan           = true
     // use_canthyd         = true
     // use_methyl          = true
     // use_uniref          = true
-
-    // Lower all 
-    tiny_cpus_limit = 1
-    small_cpus_limit = 1
-    medium_cpus_limit = 2
-    big_cpus_limit = 3
-    huge_cpus_limit = 4
-
-    tiny_gb_mem_limit = 1
-    small_gb_mem_limit = 2
-    medium_gb_mem_limit = 4
-    big_gb_mem_limit = 7
-    huge_gb_mem_limit = 20
-
-    tiny_hr_time_limit = 1
-    small_hr_time_limit = 1
-    medium_hr_time_limit = 1
-    big_hr_time_limit = 1
-    huge_hr_time_limit = 1
+    annon_dbs = "merops,kofam,kegg,dbcan"
+    slurm               = true
+    partition           = 'borton-hi,borton-low'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,8 +56,12 @@ params {
     use_pfam = false
     use_merops = false
     use_uniref = false
-    use_vog = false  // TODO: Add vog annotation
+    use_vog = false  // TODO: Add vog annotation, not well supported currently
+    use_viral = false // TODO: Add viral annotation, not well supported currently
     // use_viral = false  // TODO: Add viral annotation
+
+    // Alternative way to specify databases, comma-separated list
+    annon_dbs = ""
 
     add_annotations = null
     bit_score_threshold =  60 // MMseqs threshold search to retain hits.
@@ -68,7 +72,7 @@ params {
     bin_quality = null
 
     /* Database list for generating GFF and GBK */
-    database_list = "empty"
+    database_list = "all"
     generate_gff = false
     generate_gbk = false
 
@@ -342,6 +346,15 @@ profiles {
     test      { includeConfig 'conf/test.config'      }
     test_lite { includeConfig 'conf/test_lite.config' }
     test_full { includeConfig 'conf/test_full.config' }
+    // (WARNING, this profile name may change in the future)
+    full_mode {
+        params.annotate   = true
+        params.summarize  = true
+        params.visualize  = true
+        params.traits     = true
+        params.qc         = true
+        params.annon_dbs  = 'all'
+    }
 }
 
 // Include default slurm config

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -27,6 +27,10 @@
                     "type": "boolean",
                     "description": "Run quality control steps such as collect rRNA and tRNA scans. See QC section for more options."
                 },
+                "summarize": {
+                    "type": "boolean",
+                    "description": "Summarize annotations into a distilled output file. Will use all available distillate forms unless otherwise specified with furth distill options."
+                },
                 "distill_custom": {
                     "type": "string",
                     "description": "<path/to/custom_distillate.tsv>  Custom distill file to use. Can also supply a comma separated list of custom distill files to use. If more than one file included, they must be seperated by a comma (--distill_custom path/to/file1.tsv,path/to/file2.tsv or --distill_custom 'file1.tsv,file2.tsv'). The custom distill file must be in TSV format with the first column being the gene ID and the second column being the distillate value."
@@ -218,6 +222,15 @@
                 "use_vog": {
                     "type": "boolean"
                 },
+                "use_viral": {
+                    "type": "boolean",
+                    "hidden": true
+                },
+                "annon_dbs": {
+                    "type": "string",
+                    "description": "Alternative way to specify database list for annotation. Comma sepeterated list of databases to include in the annotates. Use `all` for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,cant_hyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'. When in doubt, use the name after `use_` for each database. This option overrides individual `use_` database flags. (WARNING, this option name may change in the future)",
+                    "default": ""
+                },
                 "add_annotations": {
                     "type": "string",
                     "format": "file-path",
@@ -236,8 +249,8 @@
                 },
                 "database_list": {
                     "type": "string",
-                    "description": "Database list for generating GFF and GBK. Comma sepeterated list of databases to include in the annotates. Use empty for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,cant_hyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'",
-                    "default": "empty"
+                    "description": "Database list for generating GFF and GBK. Comma sepeterated list of databases to include in the annotates. Use `all` for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,cant_hyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'",
+                    "default": "all"
                 },
                 "generate_gff": {
                     "type": "boolean",
@@ -270,10 +283,10 @@
             }
         },
         "distill_options": {
-            "title": "Distill Options",
+            "title": "Summarize Options",
             "type": "object",
             "fa_icon": "fas fa-dna",
-            "description": "The purpose of DRAM distill is to distill down annotations based on curated distillation summary form(s). It can be ran with either --distill_topic, --distill_ecosystem, or --distill_custom (or some combination). User's may also provide a custom distillate via --distill_custom <path/to/file> (TSV forms). Distill can be ran independent of --call and --annotate however, annotations must be provided (--annotations <path/to/annotations.tsv>). Optional tRNA, rRNA and bin quality may also be provided. When using distll, you also must use kegg, ko, dbcan, or merops when you do your annotation. To get the full results, you need to use kegg or ko and dbcan and merops.",
+            "description": "The purpose of DRAM summarize is to distill down annotations based on curated distillation summary form(s). It can be ran with either just --sumarize, or currated sheets with --distill_topic, --distill_ecosystem, or --distill_custom (or some combination). User's may also provide a custom distillate via --distill_custom <path/to/file> (TSV forms). Summarize can be ran independent of --annotate however, annotations must be provided (--annotations <path/to/annotations.tsv>). Optional tRNA, rRNA and bin quality may also be provided. When using distll, you also must use kegg, ko, dbcan, or merops when you do your annotation. To get the full results, you need to use kegg or ko and dbcan and merops.",
             "properties": {
                 "distill_topic": {
                     "type": "string",

--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -14,6 +14,18 @@ workflow ANNOTATE {
     ch_fasta  // channel: [ val(input_fasta name), path(fasta) ]
     default_sheet // Path to dummy sheet
     call     // boolean: whether gene calling flag is set
+    use_kegg
+    use_kofam
+    use_dbcan
+    use_camper
+    use_fegenie
+    use_methyl
+    use_canthyd
+    use_sulfur
+    use_pfam
+    use_merops
+    use_uniref
+    use_vog
 
     main:
     n_fastas = 0
@@ -59,7 +71,25 @@ workflow ANNOTATE {
 
  
     if (params.annotate){
-        DB_SEARCH( ch_gene_locs, ch_called_proteins, default_sheet, n_fastas, call )
+        DB_SEARCH( 
+            ch_gene_locs, 
+            ch_called_proteins, 
+            default_sheet, 
+            n_fastas, 
+            call,
+            use_kegg,
+            use_kofam,
+            use_dbcan,
+            use_camper,
+            use_fegenie,
+            use_methyl,
+            use_canthyd,
+            use_sulfur,
+            use_pfam,
+            use_merops,
+            use_uniref,
+            use_vog
+            )
         ch_combined_annotations = DB_SEARCH.out.ch_combined_annotations
     }
 

--- a/subworkflows/local/db_search.nf
+++ b/subworkflows/local/db_search.nf
@@ -7,7 +7,6 @@
     IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-
 include { GENE_LOCS                                     } from "../../modules/local/annotate/gene_locs.nf"
 
 include { GENERIC_HMM_FORMATTER                         } from "../../modules/local/annotate/generic_hmm_formatter.nf"  // TODO, This has hard coded paths on the server to the python file. Need to fix this.
@@ -69,10 +68,36 @@ workflow DB_SEARCH {
     default_sheet // Path to dummy sheet
     n_fastas // Number of FASTA files to process
     call     // boolean: whether gene calling flag is set
+    use_kegg
+    use_kofam
+    use_dbcan
+    use_camper
+    use_fegenie
+    use_methyl
+    use_canthyd
+    use_sulfur
+    use_pfam
+    use_merops
+    use_uniref
+    use_vog
 
     main:
 
-    DB_CHANNEL_SETUP()
+    DB_CHANNEL_SETUP(
+        use_kegg,
+        use_kofam,
+        use_dbcan,
+        use_camper,
+        use_fegenie,
+        use_methyl,
+        use_canthyd,
+        use_sulfur,
+        use_pfam,
+        use_merops,
+        use_uniref,
+        use_vog
+
+    )
 
     ch_sql_descriptions_db = file(params.sql_descriptions_db)
     ch_kofam_list = file(params.kofam_list)
@@ -123,7 +148,7 @@ workflow DB_SEARCH {
     }
 
     // KEGG annotation
-    if (params.use_kegg) {
+    if (use_kegg) {
         ch_combined_query_locs_kegg = ch_mmseqs_query.join(ch_gene_locs)
         MMSEQS_SEARCH_KEGG( ch_combined_query_locs_kegg, DB_CHANNEL_SETUP.out.ch_kegg_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, kegg_name )
         ch_kegg_unformatted = MMSEQS_SEARCH_KEGG.out.mmseqs_search_formatted_out
@@ -134,7 +159,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_kegg_formatted)
     }
     // KOFAM annotation
-    if (params.use_kofam) {
+    if (use_kofam) {
         HMM_SEARCH_KOFAM ( ch_called_proteins, params.kofam_e_value, DB_CHANNEL_SETUP.out.ch_kofam_db )
         ch_kofam_hmms = HMM_SEARCH_KOFAM.out.hmm_search_out
 
@@ -148,7 +173,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_kofam_formatted)
     }
     // PFAM annotation
-    if (params.use_pfam) {
+    if (use_pfam) {
         ch_combined_query_locs_pfam = ch_mmseqs_query.join(ch_gene_locs)
         MMSEQS_SEARCH_PFAM( ch_combined_query_locs_pfam, DB_CHANNEL_SETUP.out.ch_pfam_mmseqs_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, pfam_name )
         ch_pfam_unformatted = MMSEQS_SEARCH_PFAM.out.mmseqs_search_formatted_out
@@ -159,7 +184,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_pfam_formatted)
     }
     // dbCAN annotation
-    if  (params.use_dbcan) {
+    if  (use_dbcan) {
 
         HMM_SEARCH_DBCAN ( ch_called_proteins, params.dbcan_e_value , DB_CHANNEL_SETUP.out.ch_dbcan_db)
         ch_dbcan_hmms = HMM_SEARCH_DBCAN.out.hmm_search_out
@@ -174,7 +199,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_dbcan_formatted)
     }
     // CAMPER annotation
-    if (params.use_camper) {
+    if (use_camper) {
         // HMM
         HMM_SEARCH_CAMPER ( ch_called_proteins, params.camper_e_value , DB_CHANNEL_SETUP.out.ch_camper_hmm_db)
         ch_camper_hmms = HMM_SEARCH_CAMPER.out.hmm_search_out
@@ -196,7 +221,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_camper_mmseqs_formatted)
     }
     // FeGenie annotation
-    if (params.use_fegenie) {
+    if (use_fegenie) {
         HMM_SEARCH_FEGENIE ( ch_called_proteins,  params.fegenie_e_value, DB_CHANNEL_SETUP.out.ch_fegenie_db )
         ch_fegenie_hmms = HMM_SEARCH_FEGENIE.out.hmm_search_out
 
@@ -209,7 +234,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_fegenie_formatted)
     }
     // Methyl annotation
-    if (params.use_methyl) {
+    if (use_methyl) {
         ch_combined_query_locs_methyl = ch_mmseqs_query.join(ch_gene_locs)
         MMSEQS_SEARCH_METHYL( ch_combined_query_locs_methyl, DB_CHANNEL_SETUP.out.ch_methyl_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, methyl_name )
         ch_methyl_mmseqs_formatted = MMSEQS_SEARCH_METHYL.out.mmseqs_search_formatted_out
@@ -217,7 +242,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_methyl_mmseqs_formatted)
     }
     // CANT-HYD annotation
-    if (params.use_canthyd) {
+    if (use_canthyd) {
         // MMseqs
         ch_combined_query_locs_canthyd = ch_mmseqs_query.join(ch_gene_locs)
         MMSEQS_SEARCH_CANTHYD( ch_combined_query_locs_canthyd, DB_CHANNEL_SETUP.out.ch_canthyd_mmseqs_db, params.bit_score_threshold, params.rbh_bit_score_threshold, DB_CHANNEL_SETUP.out.ch_canthyd_mmseqs_list, canthyd_name )
@@ -240,7 +265,7 @@ workflow DB_SEARCH {
 
     }
     // Sulfur annotation
-    if (params.use_sulfur) {
+    if (use_sulfur) {
         HMM_SEARCH_SULFUR ( ch_called_proteins,  params.sulfur_e_value, DB_CHANNEL_SETUP.out.ch_sulfur_db )
         ch_sulfur_hmms = HMM_SEARCH_SULFUR.out.hmm_search_out
 
@@ -254,7 +279,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_sulfur_formatted)
     }
     // MEROPS annotation
-    if (params.use_merops) {
+    if (use_merops) {
         ch_combined_query_locs_merops = ch_mmseqs_query.join(ch_gene_locs)
         MMSEQS_SEARCH_MEROPS( ch_combined_query_locs_merops, DB_CHANNEL_SETUP.out.ch_merops_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, merops_name )
         ch_merops_unformatted = MMSEQS_SEARCH_MEROPS.out.mmseqs_search_formatted_out
@@ -265,7 +290,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_merops_formatted)
     }
     // Uniref annotation
-    if (params.use_uniref) {
+    if (use_uniref) {
         ch_combined_query_locs_uniref = ch_mmseqs_query.join(ch_gene_locs)
         MMSEQS_SEARCH_UNIREF( ch_combined_query_locs_uniref, DB_CHANNEL_SETUP.out.ch_uniref_db, params.bit_score_threshold, params.rbh_bit_score_threshold, default_sheet, uniref_name )
         ch_uniref_unformatted = MMSEQS_SEARCH_UNIREF.out.mmseqs_search_formatted_out
@@ -276,7 +301,7 @@ workflow DB_SEARCH {
         formattedOutputChannels = formattedOutputChannels.mix(ch_uniref_formatted)
     }
     // VOGdb annotation
-    if (params.use_vog) {
+    if (use_vog) {
         HMM_SEARCH_VOG ( ch_called_proteins, params.vog_e_value , DB_CHANNEL_SETUP.out.ch_vogdb_db )
         ch_vog_hmms = HMM_SEARCH_VOG.out.hmm_search_out
 
@@ -313,6 +338,21 @@ workflow DB_SEARCH {
 }
 
 workflow DB_CHANNEL_SETUP {
+    take:
+    use_kegg
+    use_kofam
+    use_dbcan
+    use_camper
+    use_fegenie
+    use_methyl
+    use_canthyd
+    use_sulfur
+    use_pfam
+    use_merops
+    use_uniref
+    use_vog
+
+
     main:
 
     index_mmseqs = false
@@ -335,66 +375,66 @@ workflow DB_CHANNEL_SETUP {
     ch_vogdb_db = Channel.empty()
     ch_viral_db = Channel.empty()
 
-    if (params.use_kegg) {
+    if (use_kegg) {
         ch_kegg_db = file(params.kegg_db).exists() ? file(params.kegg_db) : error("Error: If using --annotate, you must supply prebuilt databases. KEGG database file not found at ${params.kegg_db}")
         index_mmseqs = true
     }
 
-    if (params.use_kofam) {
+    if (use_kofam) {
         ch_kofam_db = file(params.kofam_db).exists() ? file(params.kofam_db) : error("Error: If using --annotate, you must supply prebuilt databases. KOFAM database file not found at ${params.kofam_db}")
     }
 
-    if (params.use_dbcan) {
+    if (use_dbcan) {
         ch_dbcan_db = file(params.dbcan_db).exists() ? file(params.dbcan_db) : error("Error: If using --annotate, you must supply prebuilt databases. DBCAN database file not found at ${params.dbcan_db}")
     }
 
-    if (params.use_camper) {
+    if (use_camper) {
         ch_camper_hmm_db = file(params.camper_hmm_db).exists() ? file(params.camper_hmm_db) : error("Error: If using --annotate, you must supply prebuilt databases. CAMPER HMM database file not found at ${params.camper_hmm_db}")
         ch_camper_mmseqs_db = file(params.camper_mmseqs_db).exists() ? file(params.camper_mmseqs_db) : error("Error: If using --annotate, you must supply prebuilt databases. CAMPER MMseqs2 database file not found at ${params.camper_mmseqs_db}")
         index_mmseqs = true
         ch_camper_mmseqs_list = file(params.camper_mmseqs_list)
     }
 
-    if (params.use_merops) {
+    if (use_merops) {
         ch_merops_db = file(params.merops_db).exists() ? file(params.merops_db) : error("Error: If using --annotate, you must supply prebuilt databases. MEROPS database file not found at ${params.merops_db}")
         index_mmseqs = true
     }
 
-    if (params.use_pfam) {
+    if (use_pfam) {
         ch_pfam_mmseqs_db = file(params.pfam_mmseq_db).exists() ? file(params.pfam_mmseq_db) : error("Error: If using --annotate, you must supply prebuilt databases. PFAM database file not found at ${params.pfam_mmseq_db}")
         index_mmseqs = true
     }
 
-    // if (params.use_heme) {
+    // if (use_heme) {
     //     ch_heme_db = file(params.heme_db).exists() ? file(params.heme_db) : error("Error: If using --annotate, you must supply prebuilt databases. HEME database file not found at ${params.heme_db}")
     // }
 
-    if (params.use_sulfur) {
+    if (use_sulfur) {
         ch_sulfur_db = file(params.sulfur_db).exists() ? file(params.sulfur_db) : error("Error: If using --annotate, you must supply prebuilt databases. SULURR database file not found at ${params.sulfur_db}")
     }
 
-    if (params.use_uniref) {
+    if (use_uniref) {
         ch_uniref_db = file(params.uniref_db).exists() ? file(params.uniref_db) : error("Error: If using --annotate, you must supply prebuilt databases. UNIREF database file not found at ${params.uniref_db}")
         index_mmseqs = true
     }
 
-    if (params.use_methyl) {
+    if (use_methyl) {
         ch_methyl_db = file(params.methyl_db).exists() ? file(params.methyl_db) : error("Error: If using --annotate, you must supply prebuilt databases. METHYL database file not found at ${params.methyl_db}")
         index_mmseqs = true
     }
 
-    if (params.use_fegenie) {
+    if (use_fegenie) {
         ch_fegenie_db = file(params.fegenie_db).exists() ? file(params.fegenie_db) : error("Error: If using --annotate, you must supply prebuilt databases. FEGENIE database file not found at ${params.fegenie_db}")
     }
 
-    if (params.use_canthyd) {
+    if (use_canthyd) {
         ch_canthyd_hmm_db = file(params.canthyd_hmm_db).exists() ? file(params.canthyd_hmm_db) : error("Error: If using --annotate, you must supply prebuilt databases. CANT_HYD HMM database file not found at ${params.canthyd_hmm_db}")
         ch_canthyd_mmseqs_db = file(params.canthyd_mmseqs_db).exists() ? file(params.canthyd_mmseqs_db) : error("Error: If using --annotate, you must supply prebuilt databases. CANT_HYD MMseqs database file not found at ${params.canthyd_mmseqs_db}")
         index_mmseqs = true
         ch_canthyd_mmseqs_list = file(params.canthyd_mmseqs_list)
     }
 
-    if (params.use_vog) {
+    if (use_vog) {
         ch_vogdb_db = file(params.vog_db).exists() ? file(params.vog_db) : error("Error: If using --annotate, you must supply prebuilt databases. VOG database file not found at ${params.vog_db}")
     }
 

--- a/subworkflows/local/utils_nfcore_dram_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_dram_pipeline/main.nf
@@ -11,6 +11,7 @@
 include { UTILS_NFSCHEMA_PLUGIN     } from '../../nf-core/utils_nfschema_plugin'
 include { dramLogo                  } from '../../local/utils_pipeline_setup.nf'
 include { workflowCitation          } from '../../local/utils_pipeline_setup.nf'
+include { getDBFlag                 } from '../../local/utils_pipeline_setup.nf'
 include { paramsSummaryMap          } from 'plugin/nf-schema'
 include { samplesheetToList         } from 'plugin/nf-schema'
 include { paramsHelp                } from 'plugin/nf-schema'
@@ -20,6 +21,7 @@ include { completionSummary         } from '../../nf-core/utils_nfcore_pipeline'
 include { imNotification            } from '../../nf-core/utils_nfcore_pipeline'
 include { UTILS_NFCORE_PIPELINE     } from '../../nf-core/utils_nfcore_pipeline'
 include { UTILS_NEXTFLOW_PIPELINE   } from '../../nf-core/utils_nextflow_pipeline'
+
 
 
 /*
@@ -64,6 +66,24 @@ workflow PIPELINE_INITIALISATION {
     //
     // Check pipeline params that need to be validated outside of the nf-schema plugin
     //
+
+    use_kegg = params.use_kegg
+    use_fegenie = params.use_fegenie
+    use_sulfur = params.use_sulfur
+    use_pfam = params.use_pfam
+
+
+    if (params.annon_dbs != "") {
+        annon_dbs = params.annon_dbs.tokenize(',').collect { it.trim().toLowerCase() }
+        value_for_all = 'all'
+        use_kegg = getDBFlag(annon_dbs, 'kegg', value_for_all)
+        use_fegenie = getDBFlag(annon_dbs, 'fegenie', value_for_all)
+        use_sulfur = getDBFlag(annon_dbs, 'sulfur', value_for_all)
+        // use_pfam = getDBFlag(annon_dbs, 'pfam', value_for_all)
+        // PFAM database is currently disabled in this pipeline due to a bug in the DRAM2 implementation with the PFAM database. It will be re-enabled in a future release.
+    }
+
+
     if (params.input_genes) {
         if (params.call) {
             error("Input genes file cannot be used with --call. Input genes is used when you are running annotate without call.")
@@ -79,14 +99,14 @@ workflow PIPELINE_INITIALISATION {
         }
     }
 
-    if ((params.adjectives || params.visualize) && (!params.use_kegg || !params.use_fegenie || !params.use_sulfur)) {
+    if ((params.adjectives || params.visualize) && (!use_kegg || !use_fegenie || !use_sulfur)) {
         // If they are using a premade annotations file, we just trust that they used kegg, fegenies, or sulfur
         if (!params.annotations) {
             error("When using Adjectives, make sure you use Kegg, FeGenie, and Sulfur Databases")
         }
     }
 
-    if (params.use_pfam) {
+    if (use_pfam) {
         error("PFAM database is currently disabled in this pipeline due to a bug in the DRAM2 implementation with the PFAM database. It will be re-enabled in a future release.")
     }
 

--- a/subworkflows/local/utils_pipeline_setup.nf
+++ b/subworkflows/local/utils_pipeline_setup.nf
@@ -60,3 +60,13 @@ def workflowCitation() {
         "* Software dependencies\n" +
         "  https://github.com/${workflow.manifest.name}/blob/master/CITATIONS.md"
 }  // TODO add DOI for DRAM
+
+def getDBFlag(db_list, db_name, value_for_all) {
+    if (db_list.contains(value_for_all)) {
+        return true
+    } else if (db_list.contains(db_name)) {
+        return true
+    } else {
+        return false
+    }
+}

--- a/workflows/dram.nf
+++ b/workflows/dram.nf
@@ -4,12 +4,13 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { MULTIQC                } from '../modules/nf-core/multiqc/main'
-include { paramsSummaryMap       } from 'plugin/nf-schema'
-include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_dram_pipeline'
-include { getFastaChannel        } from '../subworkflows/local/utils_pipeline_setup.nf'
+include { MULTIQC                 } from '../modules/nf-core/multiqc/main'
+include { paramsSummaryMap        } from 'plugin/nf-schema'
+include { paramsSummaryMultiqc    } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { softwareVersionsToYAML  } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { methodsDescriptionText  } from '../subworkflows/local/utils_nfcore_dram_pipeline'
+include { getFastaChannel         } from '../subworkflows/local/utils_pipeline_setup.nf'
+include { getDBFlag               } from '../subworkflows/local/utils_pipeline_setup.nf'
 
 // Pipeline steps
 include { ADJECTIVES             } from "../modules/local/adjectives/adjectives.nf"
@@ -71,18 +72,38 @@ workflow DRAM {
         }
     }
 
-    def distill_topic_list = ""
-    def distill_ecosystem_list = ""
-    def distill_custom_list = ""
+    use_kegg = params.use_kegg
+    use_kofam = params.use_kofam
+    use_dbcan = params.use_dbcan
+    use_camper = params.use_camper
+    use_fegenie = params.use_fegenie
+    use_methyl = params.use_methyl
+    use_canthyd = params.use_canthyd
+    use_sulfur = params.use_sulfur
+    use_pfam = params.use_pfam
+    use_merops = params.use_merops
+    use_uniref = params.use_uniref
+    use_vog = params.use_vog
 
-    distill_default = "0"
-    distill_carbon = "0"
-    distill_energy = "0"
-    distill_misc = "0"
-    distill_nitrogen = "0"
-    distill_transport = "0"
-    distill_camper = "0"
-    
+    if (params.annon_dbs != "") {
+        annon_dbs = params.annon_dbs.tokenize(',').collect { it.trim().toLowerCase() }
+        value_for_all = 'all'
+        use_kegg = getDBFlag(annon_dbs, 'kegg', value_for_all)
+        use_kofam = getDBFlag(annon_dbs, 'kofam', value_for_all)
+        use_dbcan = getDBFlag(annon_dbs, 'dbcan', value_for_all)
+        use_camper = getDBFlag(annon_dbs, 'camper', value_for_all)
+        use_fegenie = getDBFlag(annon_dbs, 'fegenie', value_for_all)
+        use_methyl = getDBFlag(annon_dbs, 'methyl', value_for_all)
+        use_canthyd = getDBFlag(annon_dbs, 'canthyd', value_for_all)
+        use_sulfur = getDBFlag(annon_dbs, 'sulfur', value_for_all)
+        // use_pfam = getDBFlag(annon_dbs, 'pfam', value_for_all)
+        // PFAM database is currently disabled in this pipeline due to a bug in the DRAM2 implementation with the PFAM database. It will be re-enabled in a future release.
+        use_merops = getDBFlag(annon_dbs, 'merops', value_for_all)
+        use_uniref = getDBFlag(annon_dbs, 'uniref', value_for_all)
+        use_vog = getDBFlag(annon_dbs, 'vog', value_for_all)
+    }
+
+
 
 
     if (distill_flag) {
@@ -98,8 +119,6 @@ workflow DRAM {
             }
         }
 
-        distill_eng_sys = "0"
-        distill_ag = "0"
         if (params.distill_ecosystem != "") {
             def distillEcosystemList = params.distill_ecosystem.split(',')
 
@@ -114,14 +133,6 @@ workflow DRAM {
             }
         }
 
-        /*
-        if (params.distill_custom != "") {
-            ch_distill_custom = file(params.distill_custom).exists() ? file(params.distill_custom) : error("Error: If using --distill_custom <path/to/TSV>, you must have the preformatted custom distill sheet in the provided file: ${params.distill_custom}.")
-            distill_custom_list = "params.distill_custom"
-        }else{
-            ch_distill_custom = default_sheet
-        }
-        */
         if (params.distill_custom != "") {
             // Verify the directory exists
             def custom_distill_dir = file(params.distill_custom)
@@ -150,7 +161,7 @@ workflow DRAM {
             }
         }
 
-        if (!params.use_kegg && !params.use_kofam && !params.use_dbcan && !params.use_merops) {
+        if (!use_kegg && !use_kofam && !use_dbcan && !use_merops) {
             if (!params.annotations) {
                 error("Error: If you are using --distill_<topic|ecosystem|custom>, you must also use --use_kegg, --use_kofam, --use_dbcan, or --use_merops.")
             }
@@ -206,7 +217,19 @@ workflow DRAM {
         ANNOTATE (
             ch_fasta,
             default_sheet,
-            call
+            call,
+            use_kegg,
+            use_kofam,
+            use_dbcan,
+            use_camper,
+            use_fegenie,
+            use_methyl,
+            use_canthyd,
+            use_sulfur,
+            use_pfam,
+            use_merops,
+            use_uniref,
+            use_vog
         )
 
         if( params.add_annotations ){


### PR DESCRIPTION
if you run -profile full_mode, runs all dbs and pipelines steps. This is a convenient shorthand.
Also add ability to specify annotation dbs as comma seperated with --annon_dbs, ex: --annon_dbs kegg,merops instead of --use_kegg --use_merops. These option names are still subject to change