### PR TITLE
Feature/update to dbcan3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,11 +8,12 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "mambaforge-22.9"
+    python: "miniconda-latest"
   jobs:
     pre_build:
       # Since we have to use an older nf-schema to support older nextflows, we need to update the nextflow_schema file
       # for it to output our params doc by replacing defs (needed for older nf-schema) to $defs (newer format)
+      - conda env list
       - bash ./scripts/pre_docs_install.sh
       - cat nextflow_schema.json
       - cat docs/params_doc.md

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     pre_build:
       # Since we have to use an older nf-schema to support older nextflows, we need to update the nextflow_schema file
       # for it to output our params doc by replacing defs (needed for older nf-schema) to $defs (newer format)
-      - conda env list
+      - conda list
       - bash ./scripts/pre_docs_install.sh
       - cat nextflow_schema.json
       - cat docs/params_doc.md

--- a/bin/combine_annotations.py
+++ b/bin/combine_annotations.py
@@ -1,51 +1,84 @@
 #!/usr/bin/env python
-import pandas as pd
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from skbio.io import read as read_sequence
 import os
 from pathlib import Path
-from utils.logger import get_logger
+
 import click
+import polars as pl
+from skbio.io import read as read_sequence
+
+from utils.logger import get_logger
 
 FASTA_COLUMN = os.getenv("FASTA_COLUMN", "input_fasta")
 
 logger = get_logger(filename=Path(__file__).stem)
 
 
-def read_and_preprocess(path: Path):
-    # We design input fastas from intermediate steps to be named like: "input_fasta___some_information_annotation_file.tsv"
-    input_fasta = input_fasta_from_filepath(path)
+def read_and_preprocess(
+    path: Path, input_fasta: str, seperator=","
+) -> pl.LazyFrame | None:
+    # We design input fastas from intermediate steps to be named like:
+    # "input_fasta___some_information_annotation_file.tsv"
+    # input_fasta = input_fasta_from_filepath(path)
     try:
-        df = pd.read_csv(path)
-        df[FASTA_COLUMN] = input_fasta  # Add input_fasta column
-        return df
+        lf = pl.scan_csv(path, separator=seperator).with_columns(
+            pl.lit(input_fasta).alias(FASTA_COLUMN)
+        )
+        # Validate here so we can log file-specific parse failures before the final collect.
+        lf.collect_schema()
+        return lf
     except Exception as e:
         logger.error(f"Error loading DataFrame for input_fasta {input_fasta}: {str(e)}")
-        return pd.DataFrame()  # Return an empty DataFrame in case of error
+        return None
 
 
-def input_fasta_from_filepath(file_path: Path):
-    return file_path.stem.split("___")[0]
+def input_fasta_from_filepath(file_path: Path, splitter="___") -> str:
+    return file_path.stem.split(splitter)[0]
 
 
-def assign_rank(row):
-    rank = "E"
-    if row.get("kegg_bitScore", 0) > 350:
-        rank = "A"
-    elif row.get("uniref_bitScore", 0) > 350:
-        rank = "B"
-    elif row.get("kegg_bitScore", 0) > 60 or row.get("uniref_bitScore", 0) > 60:
-        rank = "C"
-    elif any(row.get(f"{db}_bitScore", 0) > 60 for db in ["pfam", "dbcan", "merops"]):
-        rank = "D"
-    return rank
+def bit_score_expr(column_name: str) -> pl.Expr:
+    return pl.col(column_name).fill_null(0)
 
 
-def convert_bit_scores_to_numeric(df):
-    for col in df.columns:
-        if "_bitScore" in col:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
-    return df
+def assign_rank_expr(columns: list[str]) -> pl.Expr:
+    kegg_score = (
+        bit_score_expr("kegg_bitScore") if "kegg_bitScore" in columns else pl.lit(0)
+    )
+    uniref_score = (
+        bit_score_expr("uniref_bitScore") if "uniref_bitScore" in columns else pl.lit(0)
+    )
+    motif_checks = [
+        bit_score_expr(f"{db}_bitScore") > 60
+        for db in ["pfam", "dbcan", "merops"]
+        if f"{db}_bitScore" in columns
+    ]
+    motif_expr = pl.any_horizontal(motif_checks) if motif_checks else pl.lit(False)
+
+    return (
+        pl.when(kegg_score > 350)
+        .then(pl.lit("A"))
+        .when(uniref_score > 350)
+        .then(pl.lit("B"))
+        .when((kegg_score > 60) | (uniref_score > 60))
+        .then(pl.lit("C"))
+        .when(motif_expr)
+        .then(pl.lit("D"))
+        .otherwise(pl.lit("E"))
+        .alias("rank")
+    )
+
+
+def convert_bit_scores_to_numeric(lf: pl.LazyFrame) -> pl.LazyFrame:
+    bit_score_columns = [
+        col for col in lf.collect_schema().names() if "_bitScore" in col
+    ]
+    if not bit_score_columns:
+        return lf
+    return lf.with_columns(
+        [
+            pl.col(col).cast(pl.Float64, strict=False).alias(col)
+            for col in bit_score_columns
+        ]
+    )
 
 
 def count_motifs(gene_faa, motif="(C..CH)", genes_faa_dict=None):
@@ -89,7 +122,16 @@ def set_gene_data(gene_faa, genes_faa_dict=None):
     return genes_faa_dict
 
 
-def organize_columns(df, special_columns=None):
+def genes_dict_to_frame(genes_faa_dict: dict) -> pl.DataFrame:
+    rows = []
+    for query_id, values in genes_faa_dict.items():
+        row = {"query_id": query_id}
+        row.update(values)
+        rows.append(row)
+    return pl.DataFrame(rows) if rows else pl.DataFrame(schema={"query_id": pl.String})
+
+
+def organize_columns(df: pl.DataFrame, special_columns=None) -> pl.DataFrame:
     if special_columns is None:
         special_columns = []
     base_columns = [
@@ -114,7 +156,7 @@ def organize_columns(df, special_columns=None):
         if col not in base_columns + kegg_columns + special_columns
     ]
 
-    db_prefixes = set(col.split("_")[0] for col in other_columns)
+    db_prefixes = sorted(set(col.split("_")[0] for col in other_columns))
     sorted_other_columns = []
     for prefix in db_prefixes:
         prefixed_columns = sorted(
@@ -126,78 +168,160 @@ def organize_columns(df, special_columns=None):
     final_columns_order = (
         base_columns + kegg_columns + sorted_other_columns + special_columns
     )
-    return df[final_columns_order]
+    return df.select(final_columns_order)
 
 
 @click.command()
-@click.option("--annotations_dir", required=True, help="Directory of annotation files")
+@click.option("--annotations_dir", help="Directory of annotation files")
+@click.option("--genes_dir", help="Directory genes faa file paths from prodigal")
 @click.option(
-    "--genes_dir", required=True, help="Directory genes faa file paths from prodigal"
+    "--dbcan_dir",
+    help="Directory of run_dbcan hmm_results.tsv and sub_hmm_results.tsv",
 )
 @click.option("--output", help="Output file path for the combined annotations.")
-@click.option(
-    "--threads", help="Number of threads for parallel processing", type=int, default=4
-)
-def combine_annotations(annotations_dir, genes_dir, output, threads):
+def combine_annotations(annotations_dir, genes_dir, dbcan_dir, output):
     """Combine annotation files with ranks and avoid duplicating specific columns."""
-    annotations = Path(annotations_dir).glob("*")
-    genes_faa = Path(genes_dir).glob("*")
-    with ThreadPoolExecutor(max_workers=threads) as executor:
-        # futures = [executor.submit(read_and_preprocess, input_fasta, path) for input_fasta, path in input_fastas_and_paths]
-        futures = [
-            executor.submit(read_and_preprocess, Path(path)) for path in annotations
-        ]
-        data_frames = [future.result() for future in as_completed(futures)]
-
-    combined_data = pd.concat(data_frames, ignore_index=True)
+    annotations = sorted(Path(annotations_dir).glob("*")) if annotations_dir else []
+    genes_faa = sorted(Path(genes_dir).glob("*")) if genes_dir else []
+    dbcan_paths = (
+        sorted(Path(dbcan_dir).glob("*dbCAN_hmm_results.tsv")) if dbcan_dir else []
+    )
+    dbcan_sub_paths = (
+        sorted(Path(dbcan_dir).glob("*dbCANsub_hmm_results.tsv")) if dbcan_dir else []
+    )
+    annotation_frames = [
+        frame
+        for frame in (
+            read_and_preprocess(path, input_fasta=input_fasta_from_filepath(path))
+            for path in annotations
+        )
+        if frame is not None
+    ]
+    if annotation_frames:
+        combined_data_lf = pl.concat(annotation_frames, how="diagonal_relaxed")
+    else:
+        combined_data_lf = pl.LazyFrame(
+            schema={"query_id": pl.String, FASTA_COLUMN: pl.String}
+        )
     if genes_faa:
-        genes_faa_dict = dict()
+        genes_faa_dict = {}
         for gene_path in genes_faa:
             gene_path = str(gene_path)
-            genes_faa_dict
             count_motifs(gene_path, "(C..CH)", genes_faa_dict=genes_faa_dict)
             set_gene_data(gene_path, genes_faa_dict)
-        df = pd.DataFrame.from_dict(genes_faa_dict, orient="index")
-        columns = [col for col in df.columns.tolist() if col != FASTA_COLUMN]
-        combined_data = combined_data.drop(columns=columns, errors="ignore")
-        df.index.name = "query_id"
-        df = df.rename(columns={FASTA_COLUMN: FASTA_COLUMN + "2"})
-
-        # we use outer to get any genes that don't have hits
-        combined_data = pd.merge(combined_data, df, how="outer", on="query_id")
-        combined_data[FASTA_COLUMN] = combined_data[FASTA_COLUMN].fillna("")
-        mask = combined_data[FASTA_COLUMN] != ""
-        combined_data[FASTA_COLUMN] = combined_data[FASTA_COLUMN].where(
-            mask, other=combined_data[FASTA_COLUMN + "2"]
+        gene_lf = pl.LazyFrame(list(genes_faa_dict.values())).with_columns(
+            query_id=pl.Series(genes_faa_dict.keys())
         )
-        # TODO: fix the merge so it doesn't make this column
-        combined_data = combined_data.drop(columns=FASTA_COLUMN + "2")
+        gene_lf_cols = gene_lf.collect_schema().names()
+        columns = [col for col in gene_lf_cols if col not in (FASTA_COLUMN, "query_id")]
+        combined_data_lf = combined_data_lf.drop(columns, strict=False)
+        # Use a full join so genes without hits remain in the output.
+        combined_data_lf = combined_data_lf.join(
+            gene_lf, how="full", on="query_id", coalesce=True
+        )
+        combined_data_lf = combined_data_lf.with_columns(
+            pl.when(pl.col(FASTA_COLUMN).is_not_null() & (pl.col(FASTA_COLUMN) != ""))
+            .then(pl.col(FASTA_COLUMN))
+            .otherwise(pl.col(FASTA_COLUMN + "_right"))
+            .alias(FASTA_COLUMN)
+        ).drop(FASTA_COLUMN + "_right", strict=False)
+    if dbcan_paths:
+        dbcan_lf = pl.concat(
+            [
+                frame
+                for frame in (
+                    read_and_preprocess(
+                        path,
+                        input_fasta=input_fasta_from_filepath(path, splitter="_dbCAN"),
+                        seperator="\t",
+                    )
+                    for path in dbcan_paths
+                )
+                if frame is not None
+            ],
+            how="diagonal_relaxed",
+        )
+        dbcan_lf = dbcan_lf.select(
+            pl.col(FASTA_COLUMN),
+            pl.col("Target Name").alias("query_id"),
+            pl.col("HMM Name").str.strip_suffix(".hmm").alias("dbcan_id"),
+            pl.col("i-Evalue").alias("dbcan_i_Evalue"),
+        )
+        combined_data_lf = combined_data_lf.join(
+            dbcan_lf, how="full", on="query_id", coalesce=True
+        )
+        combined_data_lf = combined_data_lf.with_columns(
+            pl.when(pl.col(FASTA_COLUMN).is_not_null() & (pl.col(FASTA_COLUMN) != ""))
+            .then(pl.col(FASTA_COLUMN))
+            .otherwise(pl.col(FASTA_COLUMN + "_right"))
+            .alias(FASTA_COLUMN)
+        ).drop(FASTA_COLUMN + "_right", strict=False)
+    if dbcan_sub_paths:
+        dbcan_sub_lf = pl.concat(
+            [
+                frame
+                for frame in (
+                    read_and_preprocess(
+                        path,
+                        input_fasta=input_fasta_from_filepath(path, splitter="_dbCAN"),
+                        seperator="\t",
+                    )
+                    for path in dbcan_sub_paths
+                )
+                if frame is not None
+            ],
+            how="diagonal_relaxed",
+        )
+        dbcan_sub_lf = dbcan_sub_lf.select(
+            pl.col(FASTA_COLUMN),
+            pl.col("Target Name").alias("query_id"),
+            pl.col("Subfam Name").alias("dbcan_sub_id"),
+            pl.col("Subfam Composition").alias("dbcan_sub_composition"),
+            pl.col("Subfam EC").alias("dbcan_sub_ec"),
+            pl.col("Substrate").alias("dbcan_sub_substrate"),
+            pl.col("i-Evalue").alias("dbcan_sub_i_Evalue"),
+        )
+        combined_data_lf = combined_data_lf.join(
+            dbcan_sub_lf, how="full", on="query_id", coalesce=True
+        )
+        combined_data_lf = combined_data_lf.with_columns(
+            pl.when(pl.col(FASTA_COLUMN).is_not_null() & (pl.col(FASTA_COLUMN) != ""))
+            .then(pl.col(FASTA_COLUMN))
+            .otherwise(pl.col(FASTA_COLUMN + "_right"))
+            .alias(FASTA_COLUMN)
+        ).drop(FASTA_COLUMN + "_right", strict=False)
 
-    combined_data = convert_bit_scores_to_numeric(combined_data)
+    combined_data_lf = convert_bit_scores_to_numeric(combined_data_lf)
+    all_columns = combined_data_lf.collect_schema().names()
+    aggregation_exprs = []
+    for col in all_columns:
+        if col in ["query_id", FASTA_COLUMN]:
+            continue
+        if col in ["Completeness", "Contamination", "taxonomy"]:
+            aggregation_exprs.append(pl.col(col).max().alias(col))
+        else:
+            aggregation_exprs.append(pl.col(col).first(ignore_nulls=True).alias(col))
+    combined_data_lf = combined_data_lf.group_by(["query_id", FASTA_COLUMN]).agg(
+        aggregation_exprs
+    )
+    combined_data_lf = combined_data_lf.with_columns(
+        assign_rank_expr(combined_data_lf.collect_schema().names())
+    )
+    combined_data = combined_data_lf.collect()
 
-    aggregation_functions = {
-        col: "first"
-        for col in combined_data.columns
-        if col not in ["query_id", FASTA_COLUMN]
-    }
-    for col in ["Completeness", "Contamination", "taxonomy"]:
-        if col in combined_data.columns:
-            aggregation_functions[col] = "max"
-    combined_data = combined_data.groupby(
-        ["query_id", FASTA_COLUMN], as_index=False
-    ).agg(aggregation_functions)
-    # After aggregating data
-    combined_data["rank"] = combined_data.apply(assign_rank, axis=1)
-
-    # Continue with organizing columns and saving the DataFrame
     special_columns = ["Completeness", "Contamination", "taxonomy"]
     special_columns = [col for col in special_columns if col in combined_data.columns]
     combined_data = organize_columns(combined_data, special_columns=special_columns)
-    combined_data = combined_data.sort_values(
-        by=[FASTA_COLUMN, "scaffold", "gene_number"]
-    )
 
-    combined_data.to_csv(output, index=False, sep="\t")
+    sort_columns = [
+        col
+        for col in [FASTA_COLUMN, "scaffold", "gene_number"]
+        if col in combined_data.columns
+    ]
+    if sort_columns:
+        combined_data = combined_data.sort(sort_columns)
+
+    combined_data.write_csv(output, separator="\t")
     logger.info(f"Combined annotations saved to {output}, with corrected gene numbers.")
 
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -13,7 +13,7 @@
 process {
 
     publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0]}" },
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
@@ -36,26 +36,26 @@ process {
     withName: RENAME_FASTA {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: RENAME_PROTEINS {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: CALL_GENES {
         publishDir = [
             [
                 path: "${params.outdir}/ANNOTATE/PRODIGAL",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.gff') ? null : filename},
             ],
             // Save GFF files to a different folder
             [
                 path: "${params.outdir}/ANNOTATE/RENAMED_GFFS",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.gff') ? filename : null},
             ]
         ]
@@ -65,12 +65,12 @@ process {
         publishDir = [
             [
                 path: "${params.outdir}/ANNOTATE/QUAST",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.log') ? null : filename},
             ],
             [
                 path: "${params.outdir}/pipeline_info/logs",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.log') ? filename : null},
             ]
         ]
@@ -80,14 +80,14 @@ process {
     withName: GENE_LOCS {
         publishDir = [
             path: "${params.outdir}/ANNOTATE/PRODIGAL",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: TRNA_SCAN {
         publishDir = [
             enabled: false,
             path: "${params.outdir}/ANNOTATE/tRNA_rRNA",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 
@@ -95,60 +95,66 @@ process {
         publishDir = [
             enabled: false,
             path: "${params.outdir}/ANNOTATE/tRNA_rRNA",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 
     withName: TRNA_COLLECT {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 
     withName: RRNA_COLLECT {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: MMSEQS_INDEX {
         publishDir = [
             path: "${params.outdir}/ANNOTATE/MMSEQS2",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 
     withName: MMSEQS_SEARCH {
         publishDir = [
             path: "${params.outdir}/ANNOTATE/MMSEQS2",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 
     withName: ADD_SQL_DESCRIPTIONS {
         publishDir = [
             path: "${params.outdir}/ANNOTATE/MMSEQS2",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 
     withName: HMM_SEARCH {
         publishDir = [
             path: "${params.outdir}/ANNOTATE/HMM_SEARCH",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
+        ]
+    }
+    withName: RUNDBCAN_EASYSUBSTRATE {
+        publishDir = [
+            path: "${params.outdir}/ANNOTATE/RUNDBCAN_EASYSUBSTRATE",
+            mode: params.publish_dir_mode,
         ]
     }
     withName: COMBINE_ANNOTATIONS {
         publishDir = [
             [
                 path: "${params.outdir}/ANNOTATE",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.log') ? null : filename},
             ],
             [
                 path: "${params.outdir}/pipeline_info/logs",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.log') ? filename : null},
             ]
         ]
@@ -156,55 +162,55 @@ process {
     withName: COUNT_ANNOTATIONS {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: ADD_ANNOTATIONS {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: MERGE_ANNOTATIONS {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: ADD_TAXA {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: ADD_BIN_QUALITY {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: GENERATE_GFF_GENBANK {
         publishDir = [
             path: "${params.outdir}/ANNOTATE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: COMBINE_SUMMARIZE {
         publishDir = [
             path: "${params.outdir}/SUMMARIZE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: SUMMARIZE {
         publishDir = [
             [
                 path: "${params.outdir}/SUMMARIZE",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.log') ? null : filename},
             ],
             [
                 path: "${params.outdir}/pipeline_info/logs",
-                mode: 'copy',
+                mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('.log') ? filename : null},
             ]
         ]
@@ -212,13 +218,13 @@ process {
     withName: PRODUCT_HEATMAP {
         publishDir = [
             path: "${params.outdir}/VISUALIZE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
     withName: ADJECTIVES {
         publishDir = [
             path: "${params.outdir}/SUMMARIZE",
-            mode: 'copy',
+            mode: params.publish_dir_mode,
         ]
     }
 }

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - myst-parser
   - pytest>=7
   - nf-core=3.5.2
+  - nextflow=25.10.4
   - pre-commit
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sphinx>=8
   - myst-parser
   - pytest>=7
-  - nf-core=3.2.1
+  - nf-core=3.5.2
   - pre-commit
   - pip
   - pip:

--- a/modules.json
+++ b/modules.json
@@ -24,6 +24,11 @@
                         "branch": "master",
                         "git_sha": "5e748ff2b0f990949081c9e49792622eb3fe9ee9",
                         "installed_by": ["modules"]
+                    },
+                    "rundbcan/easysubstrate": {
+                        "branch": "master",
+                        "git_sha": "31d9ec502b58f4fcf026de727ad23e725473c70f",
+                        "installed_by": ["modules"]
                     }
                 }
             },

--- a/modules/local/annotate/add_sql_descriptions.nf
+++ b/modules/local/annotate/add_sql_descriptions.nf
@@ -4,7 +4,7 @@ process ADD_SQL_DESCRIPTIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     input:
     tuple val(input_fasta), path(hits_file)

--- a/modules/local/annotate/combine_annotations.nf
+++ b/modules/local/annotate/combine_annotations.nf
@@ -4,11 +4,12 @@ process COMBINE_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     input:
     path(fastas, stageAs: "annotations/*" )
     path(genes, stageAs: "genes/*" )
+    path(dbcan_output, stageAs: "dbcan/*")
 
     output:
     path "raw-annotations.tsv", emit: combined_annotations_out
@@ -21,7 +22,7 @@ process COMBINE_ANNOTATIONS {
     combine_annotations.py \\
         --annotations_dir annotations \\
         --genes_dir genes \\
-        --threads "${params.threads}" \\
+        --dbcan_dir dbcan \\
         --output raw-annotations.tsv
 
     """

--- a/modules/local/annotate/environment.yml
+++ b/modules/local/annotate/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.13
   - pandas>=2.0
+  - polars>=1.0
   - hmmer=3.4
   - mmseqs2==18.8cc5c
   - scikit-bio=0.7.1

--- a/modules/local/annotate/gene_locs.nf
+++ b/modules/local/annotate/gene_locs.nf
@@ -4,7 +4,7 @@ process GENE_LOCS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/hmmsearch.nf
+++ b/modules/local/annotate/hmmsearch.nf
@@ -4,7 +4,7 @@ process HMM_SEARCH {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/merge_annotations.nf
+++ b/modules/local/annotate/merge_annotations.nf
@@ -4,7 +4,7 @@ process MERGE_ANNOTATIONS {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     input:
     path( ch_annotations, stageAs: "annotations/*" )

--- a/modules/local/annotate/mmseqs_index.nf
+++ b/modules/local/annotate/mmseqs_index.nf
@@ -4,7 +4,7 @@ process MMSEQS_INDEX{
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     tag { input_fasta }
 

--- a/modules/local/annotate/mmseqs_search.nf
+++ b/modules/local/annotate/mmseqs_search.nf
@@ -4,7 +4,7 @@ process MMSEQS_SEARCH {
     errorStrategy 'finish'
 
     conda "${moduleDir}/environment.yml"
-    container "community.wave.seqera.io/library/python_pandas_hmmer_mmseqs2_pruned:0a22b52d960467a9"
+    container "community.wave.seqera.io/library/python_pandas_polars_hmmer_pruned:6d5bc9dfeca29b70"
 
     tag { input_fasta }
 

--- a/modules/nf-core/rundbcan/easysubstrate/environment.yml
+++ b/modules/nf-core/rundbcan/easysubstrate/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bioconda::dbcan=5.2.6

--- a/modules/nf-core/rundbcan/easysubstrate/main.nf
+++ b/modules/nf-core/rundbcan/easysubstrate/main.nf
@@ -1,0 +1,93 @@
+process RUNDBCAN_EASYSUBSTRATE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/dbcan:5.2.6--pyhdfd78af_0' :
+        'biocontainers/dbcan:5.2.6--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta),  path(input_raw_data)
+    tuple val(meta2), path(input_gff), val(gff_type)
+    path  dbcan_db
+
+    output:
+    tuple val(meta), path("${prefix}_overview.tsv")            , emit: cazyme_annotation
+    tuple val(meta), path("${prefix}_dbCAN_hmm_results.tsv")   , emit: dbcanhmm_results
+    tuple val(meta), path("${prefix}_dbCANsub_hmm_results.tsv"), emit: dbcansub_results
+    tuple val(meta), path("${prefix}_diamond.out")             , emit: dbcandiamond_results
+    tuple val(meta), path("${prefix}_cgc.gff")                 , emit: cgc_gff
+    tuple val(meta), path("${prefix}_cgc_standard_out.tsv")    , emit: cgc_standard_out
+    tuple val(meta), path("${prefix}_diamond.out.tc")          , emit: diamond_out_tc
+    tuple val(meta), path("${prefix}_TF_hmm_results.tsv")      , emit: tf_hmm_results, optional: true
+    tuple val(meta), path("${prefix}_STP_hmm_results.tsv")     , emit: stp_hmm_results
+    tuple val(meta), path("${prefix}_total_cgc_info.tsv")      , emit: total_cgc_info
+    tuple val(meta), path("${prefix}_substrate_prediction.tsv"), emit: substrate_prediction
+    tuple val(meta), path("${prefix}_synteny_pdf/")            , emit: synteny_pdf
+    path  "versions.yml"                                       , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+
+    run_dbcan easy_substrate \\
+        --mode protein \\
+        --db_dir ${dbcan_db} \\
+        --input_raw_data ${input_raw_data} \\
+        --output_dir . \\
+        --input_gff ${input_gff} \\
+        --gff_type ${gff_type} \\
+        ${args}
+
+    mv overview.tsv             ${prefix}_overview.tsv
+    mv dbCAN_hmm_results.tsv    ${prefix}_dbCAN_hmm_results.tsv
+    mv dbCANsub_hmm_results.tsv ${prefix}_dbCANsub_hmm_results.tsv
+    mv diamond.out              ${prefix}_diamond.out
+    mv cgc.gff                  ${prefix}_cgc.gff
+    mv cgc_standard_out.tsv     ${prefix}_cgc_standard_out.tsv
+    mv diamond.out.tc           ${prefix}_diamond.out.tc
+    mv STP_hmm_results.tsv      ${prefix}_STP_hmm_results.tsv
+    mv total_cgc_info.tsv       ${prefix}_total_cgc_info.tsv
+    mv CGC.faa                  ${prefix}_CGC.faa
+    mv PUL_blast.out            ${prefix}_PUL_blast.out
+    mv substrate_prediction.tsv ${prefix}_substrate_prediction.tsv
+    mv synteny_pdf/             ${prefix}_synteny_pdf/
+    if [ -f TF_hmm_results.tsv ]; then
+        mv TF_hmm_results.tsv   ${prefix}_TF_hmm_results.tsv
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        dbcan: \$(echo \$(run_dbcan version) | cut -f2 -d':' | cut -f2 -d' ')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_overview.tsv
+    touch ${prefix}_dbCAN_hmm_results.tsv
+    touch ${prefix}_dbCANsub_hmm_results.tsv
+    touch ${prefix}_diamond.out
+    touch ${prefix}_cgc.gff
+    touch ${prefix}_cgc_standard_out.tsv
+    touch ${prefix}_diamond.out.tc
+    touch ${prefix}_TF_hmm_results.tsv
+    touch ${prefix}_STP_hmm_results.tsv
+    touch ${prefix}_total_cgc_info.tsv
+    touch ${prefix}_CGC.faa
+    touch ${prefix}_PUL_blast.out
+    touch ${prefix}_substrate_prediction.tsv
+    mkdir -p ${prefix}_synteny_pdf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        dbcan: \$(echo \$(run_dbcan version) | cut -f2 -d':' | cut -f2 -d' ')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/rundbcan/easysubstrate/meta.yml
+++ b/modules/nf-core/rundbcan/easysubstrate/meta.yml
@@ -1,0 +1,195 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "rundbcan_easysubstrate"
+description: Substrate annotation module for the dbcan pipeline. This module is used
+  to annotate carbohydrate-active enzymes (CAZymes) from genomic data using the dbCAN
+  annotation tool.
+keywords:
+  - dbCAN
+  - download
+  - CAZyme
+  - CAZyme gene Cluster
+  - genomes
+tools:
+  - "dbcan":
+      description: "Standalone version of dbCAN annotation tool for automated CAZyme
+        annotation."
+      homepage: "https://bcb.unl.edu/dbCAN2/"
+      documentation: "https://run-dbcan.readthedocs.io/en/latest/"
+      tool_dev_url: "https://github.com/bcb-unl/run_dbcan"
+      doi: "10.1093/nar/gkad328"
+      licence: ["GPL v3-or-later"]
+      identifier: biotools:dbcan
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1']`
+    - input_raw_data:
+        type: file
+        description: FASTA file for protein sequences.
+        pattern: "*.{fasta,fa,faa}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044" # Sequence
+          - edam: "http://edamontology.org/format_1929" # FASTA
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1']`
+    - input_gff:
+        type: file
+        description: GFF file for protein sequences.
+        ontologies: []
+    - gff_type:
+        type: string
+        description: |
+          Type of GFF file. Options are `NCBI_prok`, `JGI`, `NCBI_euk`, and `prodigal`. This is used to parse the GFF file correctly.
+  - dbcan_db:
+      type: directory
+      description: Path to the dbCAN database directory.
+
+output:
+  cazyme_annotation:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_overview.tsv:
+          type: file
+          description: |
+            TSV file containing the results of dbCAN CAZyme annotation.
+          ontologies: []
+  dbcanhmm_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_dbCAN_hmm_results.tsv:
+          type: file
+          description: |
+            TSV file containing the detailed dbCAN HMM results for CAZyme annotation.
+          ontologies: []
+  dbcansub_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_dbCANsub_hmm_results.tsv:
+          type: file
+          description: |
+            TSV file containing the detailed dbCAN subfamily results for CAZyme annotation.
+          ontologies: []
+  dbcandiamond_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_diamond.out:
+          type: file
+          description: |
+            TSV file containing the detailed dbCAN diamond results for CAZyme annotation.
+          ontologies: []
+  cgc_gff:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_cgc.gff:
+          type: file
+          description: |
+            GFF file containing the CAZyme gene clusters (CGC) identified by dbCAN. This file is generated from the dbCAN annotation and contains the locations of CAZyme gene clusters in the genome.
+          ontologies: []
+  cgc_standard_out:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_cgc_standard_out.tsv:
+          type: file
+          description: |
+            Standard output file from dbCAN for CAZyme gene clusters (CGC) in a tabular format. This file summarizes the CAZyme gene clusters identified in the genome.
+          ontologies: []
+  diamond_out_tc:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_diamond.out.tc:
+          type: file
+          description: |
+            TSV file containing the diamond output for transporter annotation.
+          ontologies: []
+  tf_hmm_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_TF_hmm_results.tsv:
+          type: file
+          description: |
+            TSV file containing the results of Transcription factor.
+          ontologies: []
+  stp_hmm_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_STP_hmm_results.tsv:
+          type: file
+          description: |
+            TSV file containing the results of signaling transduction proteins (STP) annotation.
+          ontologies: []
+  total_cgc_info:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_total_cgc_info.tsv:
+          type: file
+          description: |
+            TSV file summarizing the total additional genes in the genome.
+          ontologies: []
+  substrate_prediction:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_substrate_prediction.tsv:
+          type: file
+          description: |
+            TSV file containing the substrate predictions based on the CGC annotations from dbCAN.
+          ontologies: []
+  synteny_pdf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_synteny_pdf/:
+          type: directory
+          description: |
+            Directory containing the synteny plots in PDF format for the CAZyme gene clusters (CGC) identified by dbCAN. This directory will contain one or more PDF files showing the syntenic regions of the CGC in the genome.
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@Xinpeng021001"
+maintainers:
+  - "@Xinpeng021001"

--- a/modules/nf-core/rundbcan/easysubstrate/tests/main.nf.test
+++ b/modules/nf-core/rundbcan/easysubstrate/tests/main.nf.test
@@ -1,0 +1,90 @@
+// nf-core modules test dbcan
+nextflow_process {
+
+    name "Test Process RUNDBCAN_EASYSUBSTRATE"
+    script "../main.nf"
+    process "RUNDBCAN_EASYSUBSTRATE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "rundbcan"
+    tag "rundbcan/database"
+    tag "rundbcan/easysubstrate"
+
+    test("easysubstrate - simplified") {
+
+        setup {
+            run("RUNDBCAN_DATABASE"){
+                script "../../database/main.nf"
+                process {
+                    """
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:'test'],
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/proteome.fasta', checkIfExists: true)
+                ]
+                input[1] = [
+                    [id:'test'],
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test1.gff', checkIfExists: true),
+                    "prodigal"
+                ]
+                input[2] = RUNDBCAN_DATABASE.out.dbcan_db
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.cazyme_annotation,
+                    process.out.dbcanhmm_results,
+                    process.out.dbcansub_results,
+                    process.out.dbcandiamond_results,
+                    process.out.cgc_gff,
+                    process.out.cgc_standard_out,
+                    process.out.diamond_out_tc,
+                    process.out.tf_hmm_results,
+                    process.out.stp_hmm_results,
+                    process.out.total_cgc_info,
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("easysubstrate - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [[id: 'stub'], file('stub')]
+                input[1] = [[id: 'stub'], file('stub.gff'), "prodigal"]
+                input[2] = file('stub_db')
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                    ).match()
+                }
+            )
+        }
+    }
+}

--- a/modules/nf-core/rundbcan/easysubstrate/tests/main.nf.test.snap
+++ b/modules/nf-core/rundbcan/easysubstrate/tests/main.nf.test.snap
@@ -1,0 +1,312 @@
+{
+    "easysubstrate - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_overview.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCAN_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "10": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_substrate_prediction.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "11": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        [
+
+                        ]
+                    ]
+                ],
+                "12": [
+                    "versions.yml:md5,b3b2fdbf18a2af95cc972c93ae3d9b86"
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCANsub_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_diamond.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_cgc.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_cgc_standard_out.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_diamond.out.tc:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_TF_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_STP_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "9": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_total_cgc_info.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cazyme_annotation": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_overview.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cgc_gff": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_cgc.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cgc_standard_out": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_cgc_standard_out.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "dbcandiamond_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_diamond.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "dbcanhmm_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCAN_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "dbcansub_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCANsub_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "diamond_out_tc": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_diamond.out.tc:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "stp_hmm_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_STP_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "substrate_prediction": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_substrate_prediction.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "synteny_pdf": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        [
+
+                        ]
+                    ]
+                ],
+                "tf_hmm_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_TF_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "total_cgc_info": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_total_cgc_info.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,b3b2fdbf18a2af95cc972c93ae3d9b86"
+                ]
+            },
+            {
+                "RUNDBCAN_EASYSUBSTRATE": {
+                    "dbcan": "5.2.6"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2026-02-02T13:21:03.654343854"
+    },
+    "easysubstrate - simplified": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_overview.tsv:md5,946555b9669d8e0b1705ca512ad3c60d"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dbCAN_hmm_results.tsv:md5,7ce7b6536845ffa8907b3f3fb2b77a1b"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dbCANsub_hmm_results.tsv:md5,d771df5ab5b2967ced24c04fe54abf17"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_diamond.out:md5,f6d902c0af43d8b33a41d647327c673e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_cgc.gff:md5,eaf6a6435134fa64bfdff23517910ca8"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_cgc_standard_out.tsv:md5,6be9ab29b289ff46cc6e4b6fe48dc3d7"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_diamond.out.tc:md5,be696c08c3fa3261318a347b62a5eba8"
+                ]
+            ],
+            [
+
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_STP_hmm_results.tsv:md5,c928a0bc065ba211119ad18279499cae"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_total_cgc_info.tsv:md5,86b551fe09a76b253b6c955363255af9"
+                ]
+            ],
+            [
+                "versions.yml:md5,b3b2fdbf18a2af95cc972c93ae3d9b86"
+            ],
+            {
+                "RUNDBCAN_EASYSUBSTRATE": {
+                    "dbcan": "5.2.6"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2026-02-02T15:25:26.403675169"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,6 @@ params {
     use_kegg = false
     use_kofam = false
     use_dbcan = false
-    use_dbcan3 = false
     use_camper = false
     use_fegenie = false
     use_methyl = false
@@ -122,13 +121,8 @@ params {
     kofam_list = "${launchDir}/databases/kofam/kofam_ko_list.tsv"
     // dbcan
     dbcan_db = "${launchDir}/databases/dbcan/"
-    dbcan_fam_activities = "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv"
-    dbcan_subfam_activities = "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv"
     dbcan_version = "5-2_9-13-2025"
-    // dbcan_version = "777"
-    dbcan3_db = "${launchDir}/databases/dbcan3"
-    dbcan_version_file = "${params.dbcan3_db}/version.txt"
-    dbcan3_sub_db = "${launchDir}/databases/dbcan3_sub"
+    dbcan_version_file = "${params.dbcan_db}/version.txt"
     // vogdb
     vog_db = "${launchDir}/databases/vogdb/"
     vog_list = "${launchDir}/databases/vogdb/vog_annotations_latest.tsv.gz"

--- a/nextflow.config
+++ b/nextflow.config
@@ -124,7 +124,10 @@ params {
     dbcan_db = "${launchDir}/databases/dbcan/"
     dbcan_fam_activities = "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv"
     dbcan_subfam_activities = "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv"
+    dbcan_version = "5-2_9-13-2025"
+    // dbcan_version = "777"
     dbcan3_db = "${launchDir}/databases/dbcan3"
+    dbcan_version_file = "${params.dbcan3_db}/version.txt"
     dbcan3_sub_db = "${launchDir}/databases/dbcan3_sub"
     // vogdb
     vog_db = "${launchDir}/databases/vogdb/"
@@ -151,7 +154,7 @@ params {
     // antiSMASH
     antismash_db = "${launchDir}/databases/antismash/"
     // rgi card
-    card_db = "${launchDir}/scratch/card"
+    card_db = "${launchDir}/databases/card"
     // TCDB
     tcdb_db = "${launchDir}/databases/tcdb"
     // SQL annotation descriptions database

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -148,11 +148,7 @@
                 },
                 "use_dbcan": {
                     "type": "boolean",
-                    "description": "Use the DBCan database for annotation."
-                },
-                "use_dbcan3": {
-                    "type": "boolean",
-                    "description": "Use the experimental DBCan3 databases for annotation."
+                    "description": "Use the dbCAN database for annotation."
                 },
                 "use_fegenie": {
                     "type": "boolean",
@@ -415,32 +411,12 @@
                     "default": "${launchDir}/databases/dbcan/",
                     "hidden": true
                 },
-                "dbcan_fam_activities": {
-                    "type": "string",
-                    "default": "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv",
-                    "hidden": true
-                },
-                "dbcan_subfam_activities": {
-                    "type": "string",
-                    "default": "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv",
-                    "hidden": true
-                },
                 "dbcan_version": {
                     "type": "string",
                     "hidden": true
                 },
                 "dbcan_version_file": {
                     "type": "string",
-                    "hidden": true
-                },
-                "dbcan3_db": {
-                    "type": "string",
-                    "default": "${launchDir}/databases/dbcan3/",
-                    "hidden": true
-                },
-                "dbcan3_sub_db": {
-                    "type": "string",
-                    "default": "${launchDir}/databases/dbcan3_sub/",
                     "hidden": true
                 },
                 "vog_db": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -132,7 +132,7 @@
             "properties": {
                 "anno_dbs": {
                     "type": "string",
-                    "description": "Alternative way to specify database list for annotation. Comma sepeterated list of databases to include in the annotates. Use `all` for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,cant_hyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'. When in doubt, use the name after `use_` for each database. This option overrides individual `use_` database flags. (WARNING, this option name may change in the future)"
+                    "description": "Alternative way to specify database list for annotation. Comma sepeterated list of databases to include in the annotates. Use `all` for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,canthyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'. When in doubt, use the name after `use_` for each database. This option overrides individual `use_` database flags. (WARNING, this option name may change in the future)"
                 },
                 "use_dram_db": {
                     "type": "boolean",
@@ -231,7 +231,7 @@
                 },
                 "database_list": {
                     "type": "string",
-                    "description": "Database list for generating GFF and GBK. Comma sepeterated list of databases to include in the annotates. Use `all` for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,cant_hyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'",
+                    "description": "Database list for generating GFF and GBK. Comma sepeterated list of databases to include in the annotates. Use `all` for all. Example: 'kegg,dbcan,kofam,merops,viral,camper,canthyd,fegenie,sulfur,methyl,uniref,pfam,vogdb'",
                     "default": "all"
                 },
                 "generate_gff": {
@@ -423,6 +423,14 @@
                 "dbcan_subfam_activities": {
                     "type": "string",
                     "default": "${launchDir}/databases/dbcan/dbcan.fam-activities.tsv",
+                    "hidden": true
+                },
+                "dbcan_version": {
+                    "type": "string",
+                    "hidden": true
+                },
+                "dbcan_version_file": {
+                    "type": "string",
                     "hidden": true
                 },
                 "dbcan3_db": {

--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -18,7 +18,6 @@ workflow ANNOTATE {
     use_kegg
     use_kofam
     use_dbcan
-    use_dbcan3
     use_camper
     use_fegenie
     use_methyl
@@ -153,7 +152,6 @@ workflow ANNOTATE {
             use_kegg,
             use_kofam,
             use_dbcan,
-            use_dbcan3,
             use_camper,
             use_fegenie,
             use_methyl,

--- a/subworkflows/local/annotate.nf
+++ b/subworkflows/local/annotate.nf
@@ -116,7 +116,7 @@ workflow ANNOTATE {
             tuple(meta, file)
         }
 
-    ch_rgi_map = ch_called_genes
+    ch_fna_map = ch_called_genes
         .map {
                 file_name, file ->
                 def meta = [:]
@@ -124,12 +124,30 @@ workflow ANNOTATE {
                 tuple(meta, file)
             }
 
+    ch_faa_map = ch_called_proteins
+        .map {
+                file_name, file ->
+                def meta = [:]
+                meta.id = file_name
+                tuple(meta, file)
+            }
+
+    ch_gff_map = ch_gene_gff
+        .map {
+            file ->
+            def meta = [:]
+            meta.id = file.getBaseName()
+            tuple(meta, file, "prodigal")
+        }
+
     if (params.annotate){
         DB_SEARCH(
             ch_gene_locs,
             ch_called_proteins,
             ch_antismash_map,
-            ch_rgi_map,
+            ch_fna_map,
+            ch_faa_map,
+            ch_gff_map,
             ch_gene_gff,
             default_sheet,
             use_kegg,

--- a/subworkflows/local/db_search.nf
+++ b/subworkflows/local/db_search.nf
@@ -46,6 +46,9 @@ include { HMM_SEARCH as HMM_SEARCH_METALS               } from "../../modules/lo
 
 include { ANTISMASH_ANTISMASH                           } from '../../modules/nf-core/antismash/antismash/main'
 include { RGI_MAIN                                      } from '../../modules/nf-core/rgi/main/main'
+include { RUNDBCAN_EASYSUBSTRATE                        } from '../../modules/nf-core/rundbcan/easysubstrate/main'
+
+include {checkDBVersion                                 } from '../../subworkflows/local/utils_pipeline_setup.nf'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -58,7 +61,9 @@ workflow DB_SEARCH {
     ch_gene_locs  // channel: path(gene_locs_tsv) ]
     ch_called_proteins  // channel: [ val(input_fasta name), path(called_proteins_file.faa) ]
     ch_antismash_map
-    ch_rgi_map
+    ch_fna_map
+    ch_faa_map
+    ch_gff_map
     ch_gene_gff
     default_sheet // Path to dummy sheet
     use_kegg
@@ -137,6 +142,7 @@ workflow DB_SEARCH {
     dram_db_name = "dram_db"
 
     def formattedOutputChannels = channel.of()
+    def dbcanOutputChannels = channel.of()
 
     // Here we will create mmseqs2 index files for each of the inputs if we are going to do a mmseqs2 database
     // We use .val because we need to unwrap the workflow output.
@@ -199,28 +205,13 @@ workflow DB_SEARCH {
     }
     // dbCAN3 annotation
     if  (use_dbcan3) {
-        ch_combined_proteins_locs = ch_called_proteins.join(ch_gene_locs)
-        HMM_SEARCH_DBCAN3 (
-            ch_combined_proteins_locs,
-            params.dbcan_e_value,
-            DB_CHANNEL_SETUP.out.ch_dbcan3_db,
-            default_sheet,
-            false,
-            dbcan3_name
-            )
-        ch_hmm_formatted = HMM_SEARCH_DBCAN3.out.formatted_hits
-        formattedOutputChannels = formattedOutputChannels.mix(ch_hmm_formatted)
-
-        HMM_SEARCH_DBCAN3_SUB (
-            ch_combined_proteins_locs,
-            params.dbcan_e_value,
-            DB_CHANNEL_SETUP.out.ch_dbcan3_sub_db,
-            default_sheet,
-            false,
-            dbcan3_sub_name
-            )
-        ch_hmm_formatted = HMM_SEARCH_DBCAN3_SUB.out.formatted_hits
-        formattedOutputChannels = formattedOutputChannels.mix(ch_hmm_formatted)
+        RUNDBCAN_EASYSUBSTRATE(
+            ch_faa_map,
+            ch_gff_map,
+            DB_CHANNEL_SETUP.out.ch_dbcan3_db
+        )
+        dbcanOutputChannels = dbcanOutputChannels.mix(RUNDBCAN_EASYSUBSTRATE.out.dbcanhmm_results)
+        dbcanOutputChannels = dbcanOutputChannels.mix(RUNDBCAN_EASYSUBSTRATE.out.dbcansub_results)
     }
     // CAMPER annotation
     if (use_camper) {
@@ -339,8 +330,7 @@ workflow DB_SEARCH {
     }
     // RGI with CARD
     if (use_rgi) {
-
-        RGI_MAIN(ch_rgi_map, DB_CHANNEL_SETUP.out.ch_card_db, [])
+        RGI_MAIN(ch_fna_map, DB_CHANNEL_SETUP.out.ch_card_db, [])
     }
     // CARD annotation
     if (use_card) {
@@ -394,10 +384,15 @@ workflow DB_SEARCH {
         ch_mmseqs_formatted = SQL_VIRAL.out.sql_formatted_hits
         formattedOutputChannels = formattedOutputChannels.mix(ch_mmseqs_formatted)
     }
-    fastas = formattedOutputChannels.map { it[1] }.collect()
-    genes = ch_called_proteins.map { it[1] }.collect()
 
-    COMBINE_ANNOTATIONS( fastas, genes )
+    fastas = formattedOutputChannels.map { it[1] }.toList()
+    genes = ch_called_proteins.map { it[1] }.toList()
+    dbcan_output = dbcanOutputChannels.map { it[1] }.toList()
+    COMBINE_ANNOTATIONS(
+        fastas,
+        genes,
+        dbcan_output
+    )
     ch_combined_annotations = COMBINE_ANNOTATIONS.out.combined_annotations_out
 
 
@@ -474,6 +469,7 @@ workflow DB_CHANNEL_SETUP {
     if (use_dbcan3) {
         ch_dbcan3_db = file(params.dbcan3_db).exists() ? file(params.dbcan3_db) : error("Error: If using --annotate, you must supply prebuilt databases. DBCAN3 database file not found at ${params.dbcan3_db}")
         ch_dbcan3_sub_db = file(params.dbcan3_sub_db).exists() ? file(params.dbcan3_sub_db) : error("Error: If using --annotate, you must supply prebuilt databases. DBCAN3 sub database file not found at ${params.dbcan3_sub_db}")
+        checkDBVersion(file(params.dbcan_version_file), params.dbcan_version, "dbcan")
     }
 
     if (use_camper) {

--- a/subworkflows/local/db_search.nf
+++ b/subworkflows/local/db_search.nf
@@ -33,9 +33,6 @@ include { ADD_SQL_DESCRIPTIONS as SQL_PFAM              } from "../../modules/lo
 include { ADD_SQL_DESCRIPTIONS as SQL_DBCAN             } from "../../modules/local/annotate/add_sql_descriptions.nf"
 
 include { HMM_SEARCH as HMM_SEARCH_KOFAM                } from "../../modules/local/annotate/hmmsearch.nf"
-include { HMM_SEARCH as HMM_SEARCH_DBCAN                } from "../../modules/local/annotate/hmmsearch.nf"
-include { HMM_SEARCH as HMM_SEARCH_DBCAN3               } from "../../modules/local/annotate/hmmsearch.nf"
-include { HMM_SEARCH as HMM_SEARCH_DBCAN3_SUB           } from "../../modules/local/annotate/hmmsearch.nf"
 include { HMM_SEARCH as HMM_SEARCH_DRAM_DB              } from "../../modules/local/annotate/hmmsearch.nf"
 include { HMM_SEARCH as HMM_SEARCH_VOG                  } from "../../modules/local/annotate/hmmsearch.nf"
 include { HMM_SEARCH as HMM_SEARCH_CAMPER               } from "../../modules/local/annotate/hmmsearch.nf"
@@ -69,7 +66,6 @@ workflow DB_SEARCH {
     use_kegg
     use_kofam
     use_dbcan
-    use_dbcan3
     use_camper
     use_fegenie
     use_methyl
@@ -92,7 +88,6 @@ workflow DB_SEARCH {
         use_kegg,
         use_kofam,
         use_dbcan,
-        use_dbcan3,
         use_camper,
         use_fegenie,
         use_methyl,
@@ -113,8 +108,6 @@ workflow DB_SEARCH {
 
     ch_sql_descriptions_db = file(params.sql_descriptions_db)
     ch_kofam_list = file(params.kofam_list)
-    ch_dbcan_fam = file(params.dbcan_fam_activities)
-    ch_dbcan_subfam = file(params.dbcan_subfam_activities)
     ch_vog_list = file(params.vog_list)
     ch_camper_hmm_list = file(params.camper_hmm_list)
     ch_canthyd_hmm_list = file(params.cant_hyd_hmm_list)
@@ -123,8 +116,6 @@ workflow DB_SEARCH {
 
     kegg_name = "kegg"
     dbcan_name = "dbcan"
-    dbcan3_name = "dbcan3"
-    dbcan3_sub_name = "dbcan3_sub"
     kofam_name = "kofam"
     merops_name = "merops"
     viral_name = "viral"
@@ -187,28 +178,13 @@ workflow DB_SEARCH {
         ch_mmseqs_formatted = SQL_PFAM.out.sql_formatted_hits
         formattedOutputChannels = formattedOutputChannels.mix(ch_mmseqs_formatted)
     }
-    // dbCAN annotation
-    if  (use_dbcan) {
-        ch_combined_proteins_locs = ch_called_proteins.join(ch_gene_locs)
-        HMM_SEARCH_DBCAN (
-            ch_combined_proteins_locs,
-            params.dbcan_e_value,
-            DB_CHANNEL_SETUP.out.ch_dbcan_db,
-            default_sheet,
-            false,
-            dbcan_name
-            )
-        ch_hmm_unformatted = HMM_SEARCH_DBCAN.out.formatted_hits
-        SQL_DBCAN(ch_hmm_unformatted, dbcan_name, ch_sql_descriptions_db)
-        ch_hmm_formatted = SQL_DBCAN.out.sql_formatted_hits
-        formattedOutputChannels = formattedOutputChannels.mix(ch_hmm_formatted)
-    }
+
     // dbCAN3 annotation
-    if  (use_dbcan3) {
+    if  (use_dbcan) {
         RUNDBCAN_EASYSUBSTRATE(
             ch_faa_map,
             ch_gff_map,
-            DB_CHANNEL_SETUP.out.ch_dbcan3_db
+            DB_CHANNEL_SETUP.out.ch_dbcan_db
         )
         dbcanOutputChannels = dbcanOutputChannels.mix(RUNDBCAN_EASYSUBSTRATE.out.dbcanhmm_results)
         dbcanOutputChannels = dbcanOutputChannels.mix(RUNDBCAN_EASYSUBSTRATE.out.dbcansub_results)
@@ -406,7 +382,6 @@ workflow DB_CHANNEL_SETUP {
     use_kegg
     use_kofam
     use_dbcan
-    use_dbcan3
     use_camper
     use_fegenie
     use_methyl
@@ -430,8 +405,6 @@ workflow DB_CHANNEL_SETUP {
     ch_kegg_db = Channel.empty()
     ch_kofam_db = Channel.empty()
     ch_dbcan_db = Channel.empty()
-    ch_dbcan3_db = Channel.empty()
-    ch_dbcan3_sub_db = Channel.empty()
     ch_camper_hmm_db = Channel.empty()
     ch_camper_mmseqs_db = Channel.empty()
     ch_camper_mmseqs_list = Channel.empty()
@@ -464,12 +437,7 @@ workflow DB_CHANNEL_SETUP {
 
     if (use_dbcan) {
         ch_dbcan_db = file(params.dbcan_db).exists() ? file(params.dbcan_db) : error("Error: If using --annotate, you must supply prebuilt databases. DBCAN database file not found at ${params.dbcan_db}")
-    }
-
-    if (use_dbcan3) {
-        ch_dbcan3_db = file(params.dbcan3_db).exists() ? file(params.dbcan3_db) : error("Error: If using --annotate, you must supply prebuilt databases. DBCAN3 database file not found at ${params.dbcan3_db}")
-        ch_dbcan3_sub_db = file(params.dbcan3_sub_db).exists() ? file(params.dbcan3_sub_db) : error("Error: If using --annotate, you must supply prebuilt databases. DBCAN3 sub database file not found at ${params.dbcan3_sub_db}")
-        checkDBVersion(file(params.dbcan_version_file), params.dbcan_version, "dbcan")
+        checkDBVersion(params.dbcan_version_file, params.dbcan_version, "dbcan")
     }
 
     if (use_camper) {
@@ -562,8 +530,6 @@ workflow DB_CHANNEL_SETUP {
     ch_kegg_db
     ch_kofam_db
     ch_dbcan_db
-    ch_dbcan3_db
-    ch_dbcan3_sub_db
     ch_camper_hmm_db
     ch_camper_mmseqs_db
     ch_camper_mmseqs_list

--- a/subworkflows/local/utils_pipeline_setup.nf
+++ b/subworkflows/local/utils_pipeline_setup.nf
@@ -24,13 +24,17 @@ def getDBFlag(db_list, db_name, value_for_all, db_path) {
 
 
 def checkDBVersion(version_file, db_version, db_name) {
+    if (version_file == null) {
+        error("Version file for DB ${db_name} undefined as set to null. This could mean you did not defined everything for you configuration, or are missing your configuration file in the DRAM path or on the command line.\nIt could also mean your configuration file is out of date and new parameters have been added or removed.")
+    }
+    version_file = file(version_file)
     if (!version_file.exists()) {
         error("Version file for DB ${db_name} not found at: ${version_file}")
     }
     version_file.withReader { r ->
         def version = r.readLine()
         if (version != db_version) {
-            error("Version for DB ${db_name} did not match expected version: ${db_version}. Version found: ${version}")
+            error("Version for DB ${db_name} did not match expected version: ${db_version}. Version found: ${version}. \nYou can install the latest version of the database from GLOBUS and update DRAM as well if need be.")
         }
     }
 }

--- a/subworkflows/local/utils_pipeline_setup.nf
+++ b/subworkflows/local/utils_pipeline_setup.nf
@@ -21,3 +21,16 @@ def getDBFlag(db_list, db_name, value_for_all, db_path) {
         return false
     }
 }
+
+
+def checkDBVersion(version_file, db_version, db_name) {
+    if (!version_file.exists()) {
+        error("Version file for DB ${db_name} not found at: ${version_file}")
+    }
+    version_file.withReader { r ->
+        def version = r.readLine()
+        if (version != db_version) {
+            error("Version for DB ${db_name} did not match expected version: ${db_version}. Version found: ${version}")
+        }
+    }
+}

--- a/workflows/dram.nf
+++ b/workflows/dram.nf
@@ -73,7 +73,6 @@ workflow DRAM {
     use_kegg = params.use_kegg
     use_kofam = params.use_kofam
     use_dbcan = params.use_dbcan
-    use_dbcan3 = params.use_dbcan3
     use_camper = params.use_camper
     use_fegenie = params.use_fegenie
     use_methyl = params.use_methyl
@@ -95,7 +94,6 @@ workflow DRAM {
         use_kegg = getDBFlag(anno_dbs, 'kegg', value_for_all, params.kegg_db)
         use_kofam = getDBFlag(anno_dbs, 'kofam', value_for_all, params.kofam_db)
         use_dbcan = getDBFlag(anno_dbs, 'dbcan', value_for_all, params.dbcan_db)
-        use_dbcan3 = getDBFlag(anno_dbs, 'dbcan3', value_for_all, params.dbcan3_db)
         use_camper = getDBFlag(anno_dbs, 'camper', value_for_all, params.camper_hmm_db)
         use_fegenie = getDBFlag(anno_dbs, 'fegenie', value_for_all, params.fegenie_db)
         use_methyl = getDBFlag(anno_dbs, 'methyl', value_for_all, params.methyl_db)
@@ -241,7 +239,6 @@ workflow DRAM {
             use_kegg,
             use_kofam,
             use_dbcan,
-            use_dbcan3,
             use_camper,
             use_fegenie,
             use_methyl,


### PR DESCRIPTION
[feat: Update dbcan to dbcan3 using run_dbcan tool](https://github.com/WrightonLabCSU/DRAM/commit/08111371627e96f8f8ac081711c74883e947190f)

Using the run_dbcan tooling, update our use of dbcan from
dbcan2 to dbcan3. We will use the easysubstrate call to run the
entire run_dbcan pipeline. This initial step just consumes the first
stages output and does not include the CGC or easysubstrate in our
annotation or summarize.

Add parsing for run_dbcan output to incorporate into raw-annotations.tsv

Add ability for dram to check DB version with added version file. This
is an optional, per database add-on that is currently only being used
with dbcan to ensure users are updated to dbcan3.